### PR TITLE
fix: improve kaniko upload performance

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -354,7 +354,7 @@ func (cmd *OpenCmd) getService(client kubectl.Client, namespace, host string, ge
 			continue
 		}
 
-		if service.Spec.Type == v1.ServiceTypeClusterIP {
+		if service.Spec.Type == v1.ServiceTypeClusterIP || service.Spec.Type == v1.ServiceTypeLoadBalancer {
 			if service.Spec.ClusterIP == "None" {
 				continue
 			}


### PR DESCRIPTION
### Changes
- Fixes an issue where devspace would take a long time to upload the building context to the kaniko pod
- Fixes an issue where `devspace open` would not recognize LoadBalancer services