### PR TITLE
v5.7.6

### DIFF
--- a/cmd/add/deployment.go
+++ b/cmd/add/deployment.go
@@ -20,8 +20,7 @@ type deploymentCmd struct {
 	ChartVersion string
 	ChartRepo    string
 
-	Image     string
-	Component string
+	Image string
 
 	Dockerfile string
 	Context    string
@@ -40,8 +39,6 @@ func newDeploymentCmd(f factory.Factory, globalFlags *flags.GlobalFlags) *cobra.
 Adds a new deployment to this project's devspace.yaml
 
 Examples:
-# Deploy a predefined component 
-devspace add deployment my-deployment --component=mysql
 # Deploy a local dockerfile
 devspace add deployment my-deployment --dockerfile=./Dockerfile
 devspace add deployment my-deployment --image=myregistry.io/myuser/myrepo --dockerfile=frontend/Dockerfile --context=frontend/Dockerfile
@@ -72,7 +69,6 @@ devspace add deployment my-deployment --manifests=kube/* --namespace=devspace
 
 	// Component options
 	addDeploymentCmd.Flags().StringVar(&cmd.Image, "image", "", "A docker image to deploy (e.g. dscr.io/myuser/myrepo or dockeruser/repo:0.1 or mysql:latest)")
-	addDeploymentCmd.Flags().StringVar(&cmd.Component, "component", "", "A predefined component to use (run `devspace list available-components` to see all available components)")
 	addDeploymentCmd.Flags().StringVar(&cmd.Dockerfile, "dockerfile", "", "A dockerfile")
 	addDeploymentCmd.Flags().StringVar(&cmd.Context, "context", "", "")
 
@@ -124,7 +120,7 @@ func (cmd *deploymentCmd) RunAddDeployment(f factory.Factory, cobraCmd *cobra.Co
 	} else if cmd.Image != "" {
 		newImage, newDeployment, err = configureManager.NewImageComponentDeployment(deploymentName, cmd.Image)
 	} else {
-		return errors.New("Please specifiy one of these parameters:\n--image: A docker image to deploy (e.g. dscr.io/myuser/myrepo or dockeruser/repo:0.1 or mysql:latest)\n--manifests: The kubernetes manifests to deploy (glob pattern are allowed, comma separated, e.g. manifests/** or kube/pod.yaml)\n--chart: A helm chart to deploy (e.g. ./chart or stable/mysql)\n--component: A predefined component to use (run `devspace list available-components` to see all available components)")
+		return errors.New("Please specifiy one of these parameters:\n--image: A docker image to deploy (e.g. dscr.io/myuser/myrepo or dockeruser/repo:0.1 or mysql:latest)\n--manifests: The kubernetes manifests to deploy (glob pattern are allowed, comma separated, e.g. manifests/** or kube/pod.yaml)\n--chart: A helm chart to deploy (e.g. ./chart or stable/mysql)")
 	}
 	if err != nil {
 		return err

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -22,6 +22,7 @@ type BuildCmd struct {
 	Tags []string
 
 	SkipPush                bool
+	SkipPushLocalKubernetes bool
 	AllowCyclicDependencies bool
 	VerboseDependencies     bool
 	Dependency              []string
@@ -60,6 +61,7 @@ Builds all defined images and pushes them
 	buildCmd.Flags().StringSliceVar(&cmd.Dependency, "dependency", []string{}, "Builds only the specific named dependencies")
 
 	buildCmd.Flags().BoolVar(&cmd.SkipPush, "skip-push", false, "Skips image pushing, useful for minikube deployment")
+	buildCmd.Flags().BoolVar(&cmd.SkipPushLocalKubernetes, "skip-push-local-kube", false, "Skips image pushing, if a local kubernetes environment is detected")
 
 	return buildCmd
 }
@@ -133,10 +135,10 @@ func (cmd *BuildCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 	// Build images if necessary
 	if len(cmd.Dependency) == 0 {
 		builtImages, err := f.NewBuildController(config, generatedConfig.GetActive(), client).Build(&build.Options{
-			SkipPush:     cmd.SkipPush,
-			IsDev:        true,
-			ForceRebuild: cmd.ForceBuild,
-			Sequential:   cmd.BuildSequential,
+			SkipPush:                  cmd.SkipPush,
+			SkipPushOnLocalKubernetes: cmd.SkipPushLocalKubernetes,
+			ForceRebuild:              cmd.ForceBuild,
+			Sequential:                cmd.BuildSequential,
 		}, log)
 		if err != nil {
 			if strings.Index(err.Error(), "no space left on device") != -1 {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -37,6 +37,7 @@ type DeployCmd struct {
 	VerboseDependencies bool
 
 	SkipPush                bool
+	SkipPushLocalKubernetes bool
 	AllowCyclicDependencies bool
 	Dependency              []string
 
@@ -79,6 +80,7 @@ devspace deploy --kube-context=deploy-context
 	deployCmd.Flags().BoolVar(&cmd.VerboseDependencies, "verbose-dependencies", false, "Deploys the dependencies verbosely")
 
 	deployCmd.Flags().BoolVar(&cmd.SkipPush, "skip-push", false, "Skips image pushing, useful for minikube deployment")
+	deployCmd.Flags().BoolVar(&cmd.SkipPushLocalKubernetes, "skip-push-local-kube", true, "Skips image pushing, if a local kubernetes environment is detected")
 
 	deployCmd.Flags().BoolVarP(&cmd.ForceBuild, "force-build", "b", false, "Forces to (re-)build every image")
 	deployCmd.Flags().BoolVar(&cmd.SkipBuild, "skip-build", false, "Skips building of images")
@@ -209,9 +211,10 @@ func (cmd *DeployCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd
 		builtImages := make(map[string]string)
 		if cmd.SkipBuild == false {
 			builtImages, err = f.NewBuildController(config, generatedConfig.GetActive(), client).Build(&build.Options{
-				SkipPush:     cmd.SkipPush,
-				ForceRebuild: cmd.ForceBuild,
-				Sequential:   cmd.BuildSequential,
+				SkipPush:                  cmd.SkipPush,
+				SkipPushOnLocalKubernetes: cmd.SkipPushLocalKubernetes,
+				ForceRebuild:              cmd.ForceBuild,
+				Sequential:                cmd.BuildSequential,
 			}, cmd.log)
 			if err != nil {
 				if strings.Index(err.Error(), "no space left on device") != -1 {

--- a/cmd/list/profiles.go
+++ b/cmd/list/profiles.go
@@ -62,14 +62,16 @@ func (cmd *profilesCmd) RunListProfiles(f factory.Factory, cobraCmd *cobra.Comma
 	headerColumnNames := []string{
 		"Name",
 		"Active",
+		"Description",
 	}
 
 	configRows := make([][]string, 0, len(profiles))
 
 	for _, profile := range profiles {
 		configRows = append(configRows, []string{
-			profile,
-			strconv.FormatBool(profile == generatedConfig.ActiveProfile),
+			profile.Name,
+			strconv.FormatBool(profile.Name == generatedConfig.ActiveProfile),
+			profile.Description,
 		})
 	}
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -26,6 +26,7 @@ type RenderCmd struct {
 	Tags []string
 
 	SkipPush                bool
+	SkipPushLocalKubernetes bool
 	AllowCyclicDependencies bool
 	VerboseDependencies     bool
 
@@ -68,6 +69,7 @@ deployment.
 	renderCmd.Flags().StringSliceVarP(&cmd.Tags, "tag", "t", []string{}, "Use the given tag for all built images")
 	renderCmd.Flags().BoolVar(&cmd.ShowLogs, "show-logs", false, "Shows the build logs")
 	renderCmd.Flags().BoolVar(&cmd.SkipPush, "skip-push", false, "Skips image pushing, useful for minikube deployment")
+	renderCmd.Flags().BoolVar(&cmd.SkipPushLocalKubernetes, "skip-push-local-kube", true, "Skips image pushing, if a local kubernetes environment is detected")
 	renderCmd.Flags().BoolVar(&cmd.SkipBuild, "skip-build", false, "Skips image building")
 	renderCmd.Flags().StringVar(&cmd.Deployments, "deployments", "", "Only deploy a specifc deployment (You can specify multiple deployments comma-separated")
 
@@ -161,10 +163,10 @@ func (cmd *RenderCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd
 	builtImages := map[string]string{}
 	if cmd.SkipBuild == false {
 		builtImages, err = f.NewBuildController(config, generatedConfig.GetActive(), client).Build(&build.Options{
-			SkipPush:     cmd.SkipPush,
-			IsDev:        true,
-			ForceRebuild: cmd.ForceBuild,
-			Sequential:   cmd.BuildSequential,
+			SkipPush:                  cmd.SkipPush,
+			SkipPushOnLocalKubernetes: cmd.SkipPushLocalKubernetes,
+			ForceRebuild:              cmd.ForceBuild,
+			Sequential:                cmd.BuildSequential,
 		}, log)
 		if err != nil {
 			if strings.Index(err.Error(), "no space left on device") != -1 {

--- a/cmd/use/profile.go
+++ b/cmd/use/profile.go
@@ -56,9 +56,14 @@ func (cmd *ProfileCmd) RunUseProfile(f factory.Factory, cobraCmd *cobra.Command,
 		return errors.New(message.ConfigNotFound)
 	}
 
-	profiles, err := configLoader.GetProfiles()
+	profileObjects, err := configLoader.GetProfiles()
 	if err != nil {
 		return err
+	}
+
+	profiles := []string{}
+	for _, p := range profileObjects {
+		profiles = append(profiles, p.Name)
 	}
 
 	profileName := ""

--- a/docs/versioned_docs/version-4.13/commands/devspace_add_deployment.md
+++ b/docs/versioned_docs/version-4.13/commands/devspace_add_deployment.md
@@ -44,7 +44,6 @@ devspace add deployment my-deployment --manifests=kube/* --namespace=devspace
       --chart string                                   A helm chart to deploy (e.g. ./chart or stable/mysql)
       --chart-repo string                              The helm chart repository url to use
       --chart-version string                           The helm chart version to use
-      --component devspace list available-components   A predefined component to use (run devspace list available-components to see all available components)
       --context string                                 
       --dockerfile string                              A dockerfile
   -h, --help                                           help for deployment

--- a/pkg/devspace/build/build.go
+++ b/pkg/devspace/build/build.go
@@ -1,8 +1,8 @@
 package build
 
 import (
-	"bytes"
-	"fmt"
+	"bufio"
+	"io"
 	"strings"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/generated"
@@ -176,14 +176,24 @@ func (c *controller) Build(options *Options, log logpkg.Logger) (map[string]stri
 			imagesToBuild++
 			go func() {
 				// Create a string log
-				buff := &bytes.Buffer{}
-				streamLog := logpkg.NewStreamLogger(buff, logrus.InfoLevel)
+				reader, writer := io.Pipe()
+				streamLog := logpkg.NewStreamLogger(writer, logrus.InfoLevel)
+				logsLog := logpkg.NewPrefixLogger("["+imageConfigName+"] ", logpkg.Colors[(len(logpkg.Colors)-1)-(imagesToBuild%len(logpkg.Colors))], log)
+
+				// read from the reader
+				go func() {
+					scanner := bufio.NewScanner(reader)
+					for scanner.Scan() {
+						logsLog.Info(scanner.Text())
+					}
+				}()
 
 				// Build the image
 				err := builder.Build(streamLog)
+				_ = writer.Close()
 				if err != nil {
 					c.hookExecuter.OnError(hook.StageImages, []string{imageConfigName}, hook.Context{Client: c.client, Config: c.config, Cache: c.cache, Error: err}, log)
-					errChan <- errors.Errorf("error building image %s:%s: %s %v", imageName, imageTags[0], buff.String(), err)
+					errChan <- errors.Errorf("error building image %s:%s: %v", imageName, imageTags[0], err)
 					return
 				}
 
@@ -205,11 +215,7 @@ func (c *controller) Build(options *Options, log logpkg.Logger) (map[string]stri
 	}
 
 	if options.Sequential == false && imagesToBuild > 0 {
-		defer log.StopWait()
-
 		for imagesToBuild > 0 {
-			log.StartWait(fmt.Sprintf("Building %d images...", imagesToBuild))
-
 			select {
 			case err := <-errChan:
 				c.hookExecuter.OnError(hook.StageImages, []string{hook.All}, hook.Context{Client: c.client, Config: c.config, Cache: c.cache, Error: err}, log)

--- a/pkg/devspace/build/build.go
+++ b/pkg/devspace/build/build.go
@@ -23,11 +23,11 @@ type imageNameAndTag struct {
 
 // Options describe how images should be build
 type Options struct {
-	SkipPush                 bool
-	IsDev                    bool
-	ForceRebuild             bool
-	Sequential               bool
-	IgnoreContextPathChanges bool
+	SkipPush                  bool
+	SkipPushOnLocalKubernetes bool
+	ForceRebuild              bool
+	Sequential                bool
+	IgnoreContextPathChanges  bool
 }
 
 // Controller is the main building interface

--- a/pkg/devspace/build/builder/helper/helper.go
+++ b/pkg/devspace/build/builder/helper/helper.go
@@ -30,7 +30,6 @@ type BuildHelper struct {
 	Entrypoint []string
 	Cmd        []string
 
-	IsDev      bool
 	KubeClient kubectl.Client
 }
 
@@ -40,7 +39,7 @@ type BuildHelperInterface interface {
 }
 
 // NewBuildHelper creates a new build helper for a certain engine
-func NewBuildHelper(config *latest.Config, kubeClient kubectl.Client, engineName string, imageConfigName string, imageConf *latest.ImageConfig, imageTags []string, isDev bool) *BuildHelper {
+func NewBuildHelper(config *latest.Config, kubeClient kubectl.Client, engineName string, imageConfigName string, imageConf *latest.ImageConfig, imageTags []string) *BuildHelper {
 	var (
 		dockerfilePath, contextPath = GetDockerfileAndContext(imageConf)
 		imageName                   = imageConf.Image
@@ -51,22 +50,11 @@ func NewBuildHelper(config *latest.Config, kubeClient kubectl.Client, engineName
 		entrypoint []string
 		cmd        []string
 	)
-	if isDev {
-		if config.Dev != nil && config.Dev.Interactive != nil {
-			for _, imageOverrideConfig := range config.Dev.Interactive.Images {
-				if imageOverrideConfig.Name == imageConfigName {
-					entrypoint = imageOverrideConfig.Entrypoint
-					cmd = imageOverrideConfig.Cmd
-					break
-				}
-			}
-		}
-	}
 
-	if entrypoint == nil && imageConf.Entrypoint != nil {
+	if imageConf.Entrypoint != nil {
 		entrypoint = imageConf.Entrypoint
 	}
-	if cmd == nil && imageConf.Cmd != nil {
+	if imageConf.Cmd != nil {
 		cmd = imageConf.Cmd
 	}
 
@@ -85,7 +73,6 @@ func NewBuildHelper(config *latest.Config, kubeClient kubectl.Client, engineName
 		Cmd:        cmd,
 		Config:     config,
 
-		IsDev:      isDev,
 		KubeClient: kubeClient,
 	}
 }

--- a/pkg/devspace/build/builder/kaniko/kaniko.go
+++ b/pkg/devspace/build/builder/kaniko/kaniko.go
@@ -61,7 +61,7 @@ type Builder struct {
 const waitTimeout = 20 * time.Minute
 
 // NewBuilder creates a new kaniko.Builder instance
-func NewBuilder(config *latest.Config, dockerClient docker.Client, kubeClient kubectl.Client, imageConfigName string, imageConf *latest.ImageConfig, imageTags []string, isDev bool, log logpkg.Logger) (builder.Interface, error) {
+func NewBuilder(config *latest.Config, dockerClient docker.Client, kubeClient kubectl.Client, imageConfigName string, imageConf *latest.ImageConfig, imageTags []string, log logpkg.Logger) (builder.Interface, error) {
 	buildNamespace := kubeClient.Namespace()
 	if imageConf.Build.Kaniko.Namespace != "" {
 		buildNamespace = imageConf.Build.Kaniko.Namespace
@@ -85,7 +85,7 @@ func NewBuilder(config *latest.Config, dockerClient docker.Client, kubeClient ku
 		allowInsecureRegistry: allowInsecurePush,
 
 		dockerClient: dockerClient,
-		helper:       helper.NewBuildHelper(config, kubeClient, EngineName, imageConfigName, imageConf, imageTags, isDev),
+		helper:       helper.NewBuildHelper(config, kubeClient, EngineName, imageConfigName, imageConf, imageTags),
 	}
 
 	// create pull secret

--- a/pkg/devspace/build/create_builder.go
+++ b/pkg/devspace/build/create_builder.go
@@ -39,7 +39,7 @@ func (c *controller) createBuilder(imageConfigName string, imageConf *latest.Ima
 
 		log.StartWait("Creating kaniko builder")
 		defer log.StopWait()
-		builder, err = kaniko.NewBuilder(c.config, dockerClient, c.client, imageConfigName, imageConf, imageTags, options.IsDev, log)
+		builder, err = kaniko.NewBuilder(c.config, dockerClient, c.client, imageConfigName, imageConf, imageTags, log)
 		if err != nil {
 			return nil, errors.Errorf("Error creating kaniko builder: %v", err)
 		}
@@ -76,7 +76,7 @@ func (c *controller) createBuilder(imageConfigName string, imageConf *latest.Ima
 			return c.createBuilder(imageConfigName, convertDockerConfigToKanikoConfig(imageConf), imageTags, options, log)
 		}
 
-		builder, err = docker.NewBuilder(c.config, dockerClient, c.client, imageConfigName, imageConf, imageTags, options.SkipPush, options.IsDev)
+		builder, err = docker.NewBuilder(c.config, dockerClient, c.client, imageConfigName, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes)
 		if err != nil {
 			return nil, errors.Errorf("Error creating docker builder: %v", err)
 		}

--- a/pkg/devspace/config/loader/get.go
+++ b/pkg/devspace/config/loader/get.go
@@ -29,7 +29,7 @@ type ConfigLoader interface {
 	LoadWithoutProfile() (*latest.Config, error)
 
 	ConfigPath() string
-	GetProfiles() ([]string, error)
+	GetProfiles() ([]*latest.ProfileConfig, error)
 	ParseCommands() ([]*latest.CommandConfig, error)
 
 	ResolvedVars() map[string]string

--- a/pkg/devspace/config/loader/parse.go
+++ b/pkg/devspace/config/loader/parse.go
@@ -29,7 +29,7 @@ func varMatchFn(path, key, value string) bool {
 }
 
 // GetProfiles retrieves all available profiles
-func (l *configLoader) GetProfiles() ([]string, error) {
+func (l *configLoader) GetProfiles() ([]*latest.ProfileConfig, error) {
 	path := l.ConfigPath()
 	bytes, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -47,22 +47,27 @@ func (l *configLoader) GetProfiles() ([]string, error) {
 		profiles = []interface{}{}
 	}
 
-	profileNames := []string{}
+	retProfiles := []*latest.ProfileConfig{}
 	for _, profile := range profiles {
 		profileMap, ok := profile.(map[interface{}]interface{})
 		if !ok {
 			continue
 		}
 
-		name, ok := profileMap["name"].(string)
-		if !ok {
+		profileConfig := &latest.ProfileConfig{}
+		o, err := yaml.Marshal(profileMap)
+		if err != nil {
+			continue
+		}
+		err = yaml.Unmarshal(o, profileConfig)
+		if err != nil {
 			continue
 		}
 
-		profileNames = append(profileNames, name)
+		retProfiles = append(retProfiles, profileConfig)
 	}
 
-	return profileNames, nil
+	return retProfiles, nil
 }
 
 // ParseCommands fills the variables in the data and parses the commands

--- a/pkg/devspace/config/loader/parse_test.go
+++ b/pkg/devspace/config/loader/parse_test.go
@@ -43,10 +43,6 @@ func TestGetProfiles(t *testing.T) {
 			files: map[string]interface{}{
 				"custom.yaml": map[interface{}]interface{}{
 					"profiles": []interface{}{
-						"noMap",
-						map[interface{}]interface{}{
-							"description": "Has no name",
-						},
 						map[interface{}]interface{}{
 							"name": "myprofile",
 						},
@@ -118,7 +114,7 @@ func testGetProfiles(testCase getProfilesTestCase, t *testing.T) {
 		assert.Error(t, err, testCase.expectedErr, "Wrong or no error in testCase %s", testCase.name)
 	}
 
-	assert.Equal(t, strings.Join(profiles, ", "), strings.Join(testCase.expectedProfiles, ", "), "Unexpected profiles in testCase %s", testCase.name)
+	assert.Equal(t, strings.Join(profiles, ","), strings.Join(testCase.expectedProfiles, ","), "Unexpected profiles in testCase %s", testCase.name)
 }
 
 type parseCommandsTestCase struct {

--- a/pkg/devspace/config/loader/parse_test.go
+++ b/pkg/devspace/config/loader/parse_test.go
@@ -106,7 +106,11 @@ func testGetProfiles(testCase getProfilesTestCase, t *testing.T) {
 			ConfigPath: testCase.configPath,
 		},
 	}
-	profiles, err := loader.GetProfiles()
+	profileObjects, err := loader.GetProfiles()
+	profiles := []string{}
+	for _, p := range profileObjects {
+		profiles = append(profiles, p.Name)
+	}
 
 	if testCase.expectedErr == "" {
 		assert.NilError(t, err, "Error in testCase %s", testCase.name)

--- a/pkg/devspace/config/loader/testing/fake.go
+++ b/pkg/devspace/config/loader/testing/fake.go
@@ -99,14 +99,8 @@ func (f *FakeConfigLoader) LoadWithoutProfile() (*latest.Config, error) {
 }
 
 // GetProfiles implements interface
-func (f *FakeConfigLoader) GetProfiles() ([]string, error) {
-	profiles := []string{}
-
-	for _, profile := range f.Config.Profiles {
-		profiles = append(profiles, profile.Name)
-	}
-
-	return profiles, nil
+func (f *FakeConfigLoader) GetProfiles() ([]*latest.ProfileConfig, error) {
+	return f.Config.Profiles, nil
 }
 
 // ParseCommands implements interface

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -841,6 +841,7 @@ const (
 // ProfileConfig defines a profile config
 type ProfileConfig struct {
 	Name           string                  `yaml:"name" json:"name"`
+	Description    string                  `yaml:"description" json:"description"`
 	Parent         string                  `yaml:"parent,omitempty" json:"parent,omitempty"`
 	Parents        []*ProfileParent        `yaml:"parents,omitempty" json:"parents,omitempty"`
 	Patches        []*PatchConfig          `yaml:"patches,omitempty" json:"patches,omitempty"`

--- a/pkg/devspace/deploy/deployer/kubectl/builder.go
+++ b/pkg/devspace/deploy/deployer/kubectl/builder.go
@@ -101,23 +101,10 @@ func (k *kubectlBuilder) Build(manifest string, cmd RunCommand) ([]*unstructured
 		return nil, err
 	}
 
-	return stringToUnstructuredArray(prepareResources(string(output)))
+	return stringToUnstructuredArray(string(output))
 }
 
 var diffSeparator = regexp.MustCompile(`\n---`)
-var oldDiffSeparator = regexp.MustCompile(`\napiVersion`)
-
-func prepareResources(out string) string {
-	parts := diffSeparator.Split(out, -1)
-	for i, part := range parts {
-		oldParts := oldDiffSeparator.Split(part, -1)
-		if len(oldParts) > 1 {
-			parts[i] = strings.Join(oldParts, "\n---\napiVersion")
-		}
-	}
-
-	return strings.Join(parts, "\n---")
-}
 
 // stringToUnstructuredArray splits a YAML file into unstructured objects. Returns a list of all unstructured objects
 func stringToUnstructuredArray(out string) ([]*unstructured.Unstructured, error) {

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl.go
@@ -180,7 +180,8 @@ func (d *DeployConfig) Delete(cache *generated.CacheConfig) error {
 	d.Log.StartWait("Deleting manifests with kubectl")
 	defer d.Log.StopWait()
 
-	for _, manifest := range d.Manifests {
+	for i := len(d.Manifests) - 1; i >= 0; i-- {
+		manifest := d.Manifests[i]
 		_, replacedManifest, err := d.getReplacedManifest(manifest, cache, nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Changes
- Adds a new config option `profiles.description` to describe what a profile is doing (can be viewed via `devspace list profiles`) (#1312)
- Reverses manifest deletion order in `devspace purge`
- Removes unused `--component` flag for `devspace add deployment` (#1315)
- Fixes an issue where `devspace deploy` with kubectl wouldn't deploy correctly (#1314)
- Adds new flag `--skip-push-local-kube` to `devspace dev`, `devspace deploy`, `devspace build`, `devspace render`
- Show docker logs for multiple images while building 