### PR TITLE
feat: add commands, skipImageArg and imageTagOnly for custom builds

### DIFF
--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -1,7 +1,6 @@
 package loader
 
 import (
-	fmt "fmt"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/helm/merge"
 	"github.com/loft-sh/devspace/pkg/util/log"
@@ -174,11 +173,8 @@ func validateImages(config *latest.Config) error {
 		if imageConf.Image == "" {
 			return errors.Errorf("images.%s.image is required", imageConfigName)
 		}
-		if imageConf.Build != nil && imageConf.Build.Custom != nil && imageConf.Build.Custom.Command == "" {
-			return errors.Errorf("images.%s.build.custom.command is required", imageConfigName)
-		}
-		if imageConf.Image == "" {
-			return fmt.Errorf("images.%s.image is required", imageConfigName)
+		if imageConf.Build != nil && imageConf.Build.Custom != nil && imageConf.Build.Custom.Command == "" && len(imageConf.Build.Custom.Commands) == 0 {
+			return errors.Errorf("images.%s.build.custom.command or images.%s.build.custom.commands is required", imageConfigName, imageConfigName)
 		}
 		if images[imageConf.Image] {
 			return errors.Errorf("multiple image definitions with the same image name are not allowed")

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -288,11 +288,22 @@ type KanikoAdditionalMountKeyToPath struct {
 
 // CustomConfig tells the DevSpace CLI to build with a custom build script
 type CustomConfig struct {
-	Command    string   `yaml:"command,omitempty" json:"command,omitempty"`
-	AppendArgs []string `yaml:"appendArgs,omitempty" json:"appendArgs,omitempty"`
-	Args       []string `yaml:"args,omitempty" json:"args,omitempty"`
-	ImageFlag  string   `yaml:"imageFlag,omitempty" json:"imageFlag,omitempty"`
-	OnChange   []string `yaml:"onChange,omitempty" json:"onChange,omitempty"`
+	Command  string                `yaml:"command,omitempty" json:"command,omitempty"`
+	Commands []CustomConfigCommand `yaml:"commands,omitempty" json:"commands,omitempty"`
+
+	Args         []string `yaml:"args,omitempty" json:"args,omitempty"`
+	AppendArgs   []string `yaml:"appendArgs,omitempty" json:"appendArgs,omitempty"`
+	ImageFlag    string   `yaml:"imageFlag,omitempty" json:"imageFlag,omitempty"`
+	ImageTagOnly bool     `yaml:"imageTagOnly,omitempty" json:"imageTagOnly,omitempty"`
+	SkipImageArg bool     `yaml:"skipImageArg,omitempty" json:"skipImageArg,omitempty"`
+
+	OnChange []string `yaml:"onChange,omitempty" json:"onChange,omitempty"`
+}
+
+// CustomConfigCommand holds the information about a command on a specific operating system
+type CustomConfigCommand struct {
+	Command         string `yaml:"command,omitempty" json:"command,omitempty"`
+	OperatingSystem string `yaml:"os,omitempty" json:"os,omitempty"`
 }
 
 // BuildOptions defines options for building Docker images


### PR DESCRIPTION
### Changes
- New option `images.*.build.custom.skipImageArg` to prevent devspace from adding an argument to the custom command with the image name and tag
- New option `images.*.build.custom.imageTagOnly` to add only the image tag instead of the full image name with tag as argument to the custom command (`my-image-repo.com/repo/image:my-tag` will just become `my-tag`)
- New option `images.*.build.custom.commands` to change the base command depending on the operating system. For example:
```yaml
images:
  default:
    image: test
    tags:
    - my-tag
    build:
      custom:
        # Use this command as fall back
        command: './scripts/my-bash-build-script.sh'
        # Use a special base command for windows
        commands:
        - command: './scripts/my-powershell-build-script.ps' 
          os: windows
        # DevSpace will then build on windows with:
        # ./scripts/my-powershell-build-script.ps test:my-tag
        # And on any other operating system with:
        # ./scripts/my-bash-build-script.sh test:my-tag
```
