### PR TITLE
fix: upgrade devspacehelper to amd64 architecture & fix negating patterns download

### DIFF
--- a/hack/build-all.bash
+++ b/hack/build-all.bash
@@ -57,7 +57,7 @@ shasum -a 256 "${DEVSPACE_ROOT}/release/ui.tar.gz" > "${DEVSPACE_ROOT}/release/u
 
 # build devspace helper
 echo "Building devspace helper"
-GOARCH=386 GOOS=linux go build -ldflags "-s -w -X github.com/loft-sh/devspace/helper/cmd.version=${VERSION}" -o "${DEVSPACE_ROOT}/release/devspacehelper" helper/main.go
+GOARCH=amd64 GOOS=linux go build -ldflags "-s -w -X github.com/loft-sh/devspace/helper/cmd.version=${VERSION}" -o "${DEVSPACE_ROOT}/release/devspacehelper" helper/main.go
 shasum -a 256 "${DEVSPACE_ROOT}/release/devspacehelper" > "${DEVSPACE_ROOT}/release/devspacehelper".sha256
 
 # build bin data

--- a/helper/server/ignoreparser/ignoreparser.go
+++ b/helper/server/ignoreparser/ignoreparser.go
@@ -1,0 +1,55 @@
+package ignoreparser
+
+import (
+	"github.com/pkg/errors"
+	gitignore "github.com/sabhiram/go-gitignore"
+	"strings"
+)
+
+// IgnoreParser is a wrapping interface for gitignore.IgnoreParser that
+// adds a method to find out if the parser has any negating patterns
+type IgnoreParser interface {
+	gitignore.IgnoreParser
+
+	// This is useful for optimization, since if an ignore parser has no
+	// negate patterns, we can skip certain sub trees that do are ignored
+	// by another rule.
+	HasNegatePatterns() bool
+}
+
+type ignoreParser struct {
+	gitignore.IgnoreParser
+	NegatePatterns bool
+}
+
+func (i *ignoreParser) HasNegatePatterns() bool {
+	return i.NegatePatterns
+}
+
+// CompilePaths creates a new ignore parser from a string array
+func CompilePaths(excludePaths []string) (IgnoreParser, error) {
+	if len(excludePaths) > 0 {
+		negatePattern := false
+		for _, line := range excludePaths {
+			line = strings.Trim(line, " ")
+			if line == "" {
+				continue
+			} else if line[0] == '!' {
+				negatePattern = true
+				break
+			}
+		}
+
+		gitIgnoreParser, err := gitignore.CompileIgnoreLines(excludePaths...)
+		if err != nil {
+			return nil, errors.Wrap(err, "compile ignore lines")
+		}
+
+		return &ignoreParser{
+			IgnoreParser:   gitIgnoreParser,
+			NegatePatterns: negatePattern,
+		}, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/devspace/kubectl/copy.go
+++ b/pkg/devspace/kubectl/copy.go
@@ -3,6 +3,7 @@ package kubectl
 import (
 	"archive/tar"
 	"compress/gzip"
+	"github.com/loft-sh/devspace/helper/server/ignoreparser"
 	"io"
 	"os"
 	"path/filepath"
@@ -59,7 +60,7 @@ func writeTar(writer io.Writer, localPath string, exclude []string) error {
 	}
 
 	// Compile ignore paths
-	ignoreMatcher, err := sync.CompilePaths(exclude)
+	ignoreMatcher, err := ignoreparser.CompilePaths(exclude)
 	if err != nil {
 		return errors.Wrap(err, "compile exclude paths")
 	}

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"github.com/loft-sh/devspace/helper/server/ignoreparser"
 	"io"
 	"path/filepath"
 	"runtime"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rjeczalik/notify"
-	gitignore "github.com/sabhiram/go-gitignore"
 )
 
 var syncRetries = 5
@@ -58,9 +58,9 @@ type Sync struct {
 
 	fileIndex *fileIndex
 
-	ignoreMatcher         gitignore.IgnoreParser
-	downloadIgnoreMatcher gitignore.IgnoreParser
-	uploadIgnoreMatcher   gitignore.IgnoreParser
+	ignoreMatcher         ignoreparser.IgnoreParser
+	downloadIgnoreMatcher ignoreparser.IgnoreParser
+	uploadIgnoreMatcher   ignoreparser.IgnoreParser
 
 	log log.Logger
 
@@ -152,7 +152,7 @@ func (s *Sync) Start() error {
 
 func (s *Sync) initIgnoreParsers() error {
 	if s.Options.ExcludePaths != nil {
-		ignoreMatcher, err := CompilePaths(s.Options.ExcludePaths)
+		ignoreMatcher, err := ignoreparser.CompilePaths(s.Options.ExcludePaths)
 		if err != nil {
 			return errors.Wrap(err, "compile exclude paths")
 		}
@@ -161,7 +161,7 @@ func (s *Sync) initIgnoreParsers() error {
 	}
 
 	if s.Options.DownloadExcludePaths != nil {
-		ignoreMatcher, err := CompilePaths(s.Options.DownloadExcludePaths)
+		ignoreMatcher, err := ignoreparser.CompilePaths(s.Options.DownloadExcludePaths)
 		if err != nil {
 			return errors.Wrap(err, "compile download exclude paths")
 		}
@@ -170,7 +170,7 @@ func (s *Sync) initIgnoreParsers() error {
 	}
 
 	if s.Options.UploadExcludePaths != nil {
-		ignoreMatcher, err := CompilePaths(s.Options.UploadExcludePaths)
+		ignoreMatcher, err := ignoreparser.CompilePaths(s.Options.UploadExcludePaths)
 		if err != nil {
 			return errors.Wrap(err, "compile upload exclude paths")
 		}

--- a/pkg/devspace/sync/util.go
+++ b/pkg/devspace/sync/util.go
@@ -3,25 +3,8 @@ package sync
 import (
 	"path/filepath"
 	"strings"
-
-	"github.com/juju/errors"
-	gitignore "github.com/sabhiram/go-gitignore"
 )
 
 func getRelativeFromFullPath(fullpath string, prefix string) string {
 	return strings.TrimPrefix(strings.Replace(filepath.ToSlash(fullpath[len(prefix):]), "//", "/", -1), ".")
-}
-
-// CompilePaths compiles the exclude paths into an ignore parser
-func CompilePaths(excludePaths []string) (gitignore.IgnoreParser, error) {
-	if len(excludePaths) > 0 {
-		ignoreParser, err := gitignore.CompileIgnoreLines(excludePaths...)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		return ignoreParser, nil
-	}
-
-	return nil, nil
 }


### PR DESCRIPTION
### Changes
- Fixes an issue where the devspace helper couldn't be executed on docker desktop v3.2.0 (#1334)
- Fixes an issue where negating exclude patterns were not working correctly for sync download (#1335)