### PR TITLE
feat: allow variables in vars default

### DIFF
--- a/docs/pages/configuration/variables/basics.mdx
+++ b/docs/pages/configuration/variables/basics.mdx
@@ -96,6 +96,7 @@ The `source` option of a config variable expects either:
 - `all` means to check environment variables **first** and then ask a question if no env variable is defined (**default**)
 - [`env`](../../configuration/variables/source-env.mdx) means to check environment variables **only**
 - [`input`](../../configuration/variables/source-input.mdx) means to ask the user a question **once** (values will be cached in `.devspace/generated.yaml`)
+- [`command`](../../configuration/variables/source-command.mdx) means DevSpace will not ask the user a question and instead execute a command to determine the value of the variable.
 :::
 
 :::warning Pass Variables via CLI

--- a/docs/pages/configuration/variables/source-none.mdx
+++ b/docs/pages/configuration/variables/source-none.mdx
@@ -15,6 +15,9 @@ vars:
 - name: MYSQL_VERSION
   source: none
   default: "5.5"
+- name: NAMESPACE
+  source: none
+  default: ${DEVSPACE_NAMESPACE}
 ```
 
 

--- a/docs/pages/fragments/vars-default.mdx
+++ b/docs/pages/fragments/vars-default.mdx
@@ -1,5 +1,27 @@
-The `default` option expects a string defining the default value for the variable.
+The `default` option expects a string, integer or boolean defining the default value for the variable. You can also use other variables in a default value, with one of the following conditions being true:
+- The used variable is defined before the variable that wants to use it
+- The used variable is a predefined variable
 
 :::note Type Casting
 If a default value is specified, DevSpace will assume the type of the default value as the type for the variable, i.e. when `default: "123"` is defined and a value of `123` (int) is provided it would be casted to `"123"` (string). To explicitly use the value of a variable as a string within `devspace.yaml`, use `$!{VAR_NAME}` instead of `${VAR_NAME}`.
 :::
+
+Example:
+```yaml
+images:
+  default:
+    image: ${IMAGE}
+vars:
+  - name: IMAGE_REPOSITORY
+    default: myrepository
+    source: none
+  - name: IMAGE_NAME
+    default: devspace
+    source: none
+  - name: IMAGE
+    default: ${IMAGE_REPOSITORY}/${IMAGE_NAME}
+    source: none
+  - name: NAMESPACE
+    default: ${DEVSPACE_NAMESPACE}
+    source: none
+```

--- a/pkg/devspace/config/loader/parse.go
+++ b/pkg/devspace/config/loader/parse.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"fmt"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable"
 	"github.com/loft-sh/devspace/pkg/util/log"
 	"path/filepath"
@@ -89,7 +90,7 @@ func (l *configLoader) parseConfig(resolver variable.Resolver, data map[interfac
 // fillVariables fills in the given vars into the prepared config
 func (l *configLoader) fillVariables(resolver variable.Resolver, preparedConfig map[interface{}]interface{}, vars []*latest.Variable, options *ConfigOptions) error {
 	// Find out what vars are really used
-	varsUsed, err := resolver.FindVariables(preparedConfig)
+	varsUsed, err := resolver.FindVariables(preparedConfig, vars)
 	if err != nil {
 		return err
 	}
@@ -129,6 +130,8 @@ func (l *configLoader) fillVariables(resolver variable.Resolver, preparedConfig 
 func (l *configLoader) askQuestions(resolver variable.Resolver, vars []*latest.Variable) error {
 	for _, definition := range vars {
 		name := strings.TrimSpace(definition.Name)
+
+		fmt.Println(definition.Name)
 
 		// fill the variable with definition
 		_, err := resolver.Resolve(name, definition)

--- a/pkg/devspace/config/loader/variable/resolver.go
+++ b/pkg/devspace/config/loader/variable/resolver.go
@@ -56,7 +56,7 @@ func (r *resolver) ReplaceString(str string) (interface{}, error) {
 	})
 }
 
-func (r *resolver) FindVariables(haystack map[interface{}]interface{}) (map[string]bool, error) {
+func (r *resolver) FindVariables(haystack map[interface{}]interface{}, vars []*latest.Variable) (map[string]bool, error) {
 	// find out what vars are really used
 	varsUsed := map[string]bool{}
 	err := walk.Walk(haystack, varMatchFn, func(value string) (interface{}, error) {
@@ -69,6 +69,16 @@ func (r *resolver) FindVariables(haystack map[interface{}]interface{}) (map[stri
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// find out what vars are used within other vars default values
+	for _, v := range vars {
+		if strDefault, ok := v.Default.(string); ok {
+			_, _ = varspkg.ParseString(strDefault, func(v string) (interface{}, error) {
+				varsUsed[v] = true
+				return "", nil
+			})
+		}
 	}
 
 	return varsUsed, nil
@@ -100,6 +110,17 @@ func (r *resolver) Resolve(name string, definition *latest.Variable) (interface{
 		return v, nil
 	}
 
+	// if the definition has a default value, we try to resolve possible variables
+	// in that definition from the cache (or predefined) before continuing
+	if definition != nil && definition.Default != nil {
+		resolvedDefaultValue, err := r.resolveDefaultValue(definition)
+		if err != nil {
+			return nil, err
+		}
+
+		definition.Default = resolvedDefaultValue
+	}
+
 	// fill the variable if not found
 	value, err := r.fillVariable(name, definition)
 	if err != nil {
@@ -109,6 +130,29 @@ func (r *resolver) Resolve(name string, definition *latest.Variable) (interface{
 	// set variable so that we don't ask again
 	r.memoryCache[name] = value
 	return value, nil
+}
+
+func (r *resolver) resolveDefaultValue(definition *latest.Variable) (interface{}, error) {
+	// check if default value is a string
+	defaultString, ok := definition.Default.(string)
+	if !ok {
+		return definition.Default, nil
+	}
+
+	return varspkg.ParseString(defaultString, func(varName string) (interface{}, error) {
+		v, ok := r.memoryCache[varName]
+		if !ok {
+			// check if its a predefined variable
+			variable, err := NewPredefinedVariable(varName, r.persistentCache, r.options)
+			if err != nil {
+				return nil, errors.Errorf("variable %s was not resolved yet, however is used in the default value of variable %s. Please make sure you define %s before %s", varName, definition.Name, varName, definition.Name)
+			}
+
+			return variable.Load(definition)
+		}
+
+		return v, nil
+	})
 }
 
 func (r *resolver) fillVariable(name string, definition *latest.Variable) (interface{}, error) {

--- a/pkg/devspace/config/loader/variable/types.go
+++ b/pkg/devspace/config/loader/variable/types.go
@@ -16,7 +16,7 @@ type Resolver interface {
 	ConvertFlags(flags []string) (map[string]interface{}, error)
 
 	// FindVariables returns all variable names that were found in the given map
-	FindVariables(haystack map[interface{}]interface{}) (map[string]bool, error)
+	FindVariables(haystack map[interface{}]interface{}, vars []*latest.Variable) (map[string]bool, error)
 
 	// FillVariables walks over the haystack and replaces all encountered variables
 	FillVariables(haystack map[interface{}]interface{}) error


### PR DESCRIPTION
### Changes
- DevSpace now allows to specify variables within other variables default values, which makes it possible to compose variables of other variables. To use a variable in a default value, the variable that is used needs to be specified prior or needs to be a predefined variable. For example:
```yaml
version: v1beta9
images:
  default:
    image: ${IMAGE}
vars:
  - name: IMAGE_REPOSITORY
    default: myrepository
    source: none
  - name: IMAGE_NAME
    default: devspace
    source: none
  - name: IMAGE
    default: ${IMAGE_REPOSITORY}/${IMAGE_NAME}
    source: none
  - name: NAMESPACE
    default: ${DEVSPACE_NAMESPACE}
    source: none
```