### PR TITLE
feat: vars.value, commands.args, vars.command & --all

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -106,6 +106,13 @@ func (cmd *RunCmd) RunRun(f factory.Factory, cobraCmd *cobra.Command, args []str
 		return errors.New(message.ConfigNotFound)
 	}
 
+	// check if dependency command
+	commandSplitted := strings.Split(args[0], ".")
+	if len(commandSplitted) == 2 {
+		cmd.Dependency = commandSplitted[0]
+		args[0] = commandSplitted[1]
+	}
+
 	// check if we should execute a dependency command
 	if cmd.Dependency != "" {
 		config, err := configLoader.Load(configOptions, f.GetLog())
@@ -114,9 +121,9 @@ func (cmd *RunCmd) RunRun(f factory.Factory, cobraCmd *cobra.Command, args []str
 		}
 
 		return f.NewDependencyManager(config, nil, configOptions, f.GetLog()).Command(dependency.CommandOptions{
-			Dependencies: []string{cmd.Dependency},
-			Command:      args[0],
-			Args:         args[1:],
+			Dependency: cmd.Dependency,
+			Command:    args[0],
+			Args:       args[1:],
 		})
 	}
 

--- a/pkg/devspace/config/loader/variable/command_variable.go
+++ b/pkg/devspace/config/loader/variable/command_variable.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/util/command"
+	"github.com/loft-sh/devspace/pkg/util/shell"
 	"github.com/pkg/errors"
 	"strings"
 )
@@ -45,7 +46,12 @@ func variableFromCommand(varName string, definition *latest.Variable) (interface
 func execCommand(varName string, definition *latest.Variable, cmd string, args []string) (interface{}, error) {
 	writer := &bytes.Buffer{}
 	stdErrWriter := &bytes.Buffer{}
-	err := command.ExecuteCommand(cmd, args, writer, stdErrWriter)
+	var err error
+	if args == nil {
+		err = shell.ExecuteShellCommand(cmd, writer, stdErrWriter, nil)
+	} else {
+		err = command.ExecuteCommand(cmd, args, writer, stdErrWriter)
+	}
 	if err != nil {
 		errMsg := "fill variable " + varName + ": " + err.Error()
 		if len(writer.Bytes()) > 0 {

--- a/pkg/devspace/config/loader/variable/resolver.go
+++ b/pkg/devspace/config/loader/variable/resolver.go
@@ -180,6 +180,16 @@ func (r *resolver) fillVariableDefinition(definition *latest.Variable) error {
 		return nil
 	}
 
+	// this converts the definition.Value to definition.Default
+	if definition.Value != nil {
+		if definition.Default != nil {
+			return fmt.Errorf(".default cannot be used with .value together for variable ${%s}", definition.Name)
+		}
+
+		definition.Default = definition.Value
+		definition.Source = latest.VariableSourceNone
+	}
+
 	// if the definition has a default value, we try to resolve possible variables
 	// in that definition from the cache (or predefined) before continuing
 	if definition.Default != nil {

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1002,24 +1002,47 @@ type HookWhenAtConfig struct {
 
 // CommandConfig defines the command specification
 type CommandConfig struct {
-	Name        string `yaml:"name" json:"name"`
-	Command     string `yaml:"command" json:"command"`
+	// Name is the name of a command that is used via `devspace run NAME`
+	Name string `yaml:"name" json:"name"`
+
+	// Command is the command that should be executed. For example: 'echo 123'
+	Command string `yaml:"command" json:"command"`
+
+	// Args are optional and if defined, command is not executed within a shell
+	// and rather directly.
+	Args []string `yaml:"args,omitempty" json:"args,omitempty"`
+
+	// Description describes what the command is doing and can be seen in `devspace list commands`
 	Description string `yaml:"description" json:"description"`
 }
 
 // Variable describes the var definition
 type Variable struct {
-	Name              string         `yaml:"name" json:"name"`
-	Question          string         `yaml:"question,omitempty" json:"question,omitempty"`
-	Options           []string       `yaml:"options,omitempty" json:"options,omitempty"`
-	Password          bool           `yaml:"password,omitempty" json:"password,omitempty"`
-	ValidationPattern string         `yaml:"validationPattern,omitempty" json:"validationPattern,omitempty"`
-	ValidationMessage string         `yaml:"validationMessage,omitempty" json:"validationMessage,omitempty"`
-	Default           interface{}    `yaml:"default,omitempty" json:"default,omitempty"`
-	Source            VariableSource `yaml:"source,omitempty" json:"source,omitempty"`
+	Name              string   `yaml:"name" json:"name"`
+	Question          string   `yaml:"question,omitempty" json:"question,omitempty"`
+	Options           []string `yaml:"options,omitempty" json:"options,omitempty"`
+	Password          bool     `yaml:"password,omitempty" json:"password,omitempty"`
+	ValidationPattern string   `yaml:"validationPattern,omitempty" json:"validationPattern,omitempty"`
+	ValidationMessage string   `yaml:"validationMessage,omitempty" json:"validationMessage,omitempty"`
 
-	Command  string            `yaml:"command,omitempty" json:"command,omitempty"`
-	Args     []string          `yaml:"args,omitempty" json:"args,omitempty"`
+	// Value is a shortcut for using source: none and default: my-value
+	Value interface{} `yaml:"value,omitempty" json:"value,omitempty"`
+
+	// Default is the default value the variable should have if not set by the user
+	Default interface{} `yaml:"default,omitempty" json:"default,omitempty"`
+
+	// Source defines where the variable should be taken from
+	Source VariableSource `yaml:"source,omitempty" json:"source,omitempty"`
+
+	// Command is the command how to retrieve the variable. If args is omitted, command is parsed as a shell
+	// command.
+	Command string `yaml:"command,omitempty" json:"command,omitempty"`
+
+	// Args are optional args that will be used for the command
+	Args []string `yaml:"args,omitempty" json:"args,omitempty"`
+
+	// Commands are additional commands that can be used to run a different command on a different operating
+	// system.
 	Commands []VariableCommand `yaml:"commands,omitempty" json:"commands,omitempty"`
 }
 

--- a/pkg/devspace/hook/local_command.go
+++ b/pkg/devspace/hook/local_command.go
@@ -2,12 +2,12 @@ package hook
 
 import (
 	"encoding/json"
-	command2 "github.com/loft-sh/devspace/pkg/devspace/command"
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/util/command"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
+	"github.com/loft-sh/devspace/pkg/util/shell"
 	"io"
 	"os"
 )
@@ -43,7 +43,7 @@ func (l *localCommandHook) Execute(ctx Context, hook *latest.HookConfig, config 
 
 	// if args are nil we execute the command in a shell
 	if hook.Args == nil {
-		return command2.ExecuteShellCommand(hook.Command, l.Stdout, l.Stderr, extraEnv)
+		return shell.ExecuteShellCommand(hook.Command, l.Stdout, l.Stderr, extraEnv)
 	}
 
 	// else we execute it directly

--- a/pkg/devspace/kubectl/client.go
+++ b/pkg/devspace/kubectl/client.go
@@ -30,25 +30,25 @@ import (
 
 // Client holds all kubernetes related functions
 type Client interface {
-	// Returns the current kube context name
+	// CurrentContext returns the current kube context name
 	CurrentContext() string
 
-	// Returns an interface to a kube client
+	// KubeClient returns an interface to a kube client
 	KubeClient() kubernetes.Interface
 
-	// Returns the default namespace of the kube context
+	// Namespace returns the default namespace of the kube context
 	Namespace() string
 
-	// Returns the underlying kube rest config
+	// RestConfig returns the underlying kube rest config
 	RestConfig() *rest.Config
 
-	// Returns the underlying kube client config
+	// ClientConfig returns the underlying kube client config
 	ClientConfig() clientcmd.ClientConfig
 
-	// Returns the kube config loader interface
+	// KubeConfigLoader returns the kube config loader interface
 	KubeConfigLoader() kubeconfig.Loader
 
-	// This function will print a warning if the generated config contains a different last kube context / namespace
+	// PrintWarning this function will print a warning if the generated config contains a different last kube context / namespace
 	// than the one that is used currently
 	PrintWarning(generatedConfig *generated.Config, noWarning, shouldWait bool, log log.Logger) error
 

--- a/pkg/util/shell/shell.go
+++ b/pkg/util/shell/shell.go
@@ -1,0 +1,45 @@
+package shell
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"io"
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
+	"os"
+	"strings"
+)
+
+func ExecuteShellCommand(command string, stdout io.Writer, stderr io.Writer, extraEnvVars map[string]string) error {
+	env := os.Environ()
+	for k, v := range extraEnvVars {
+		env = append(env, k+"="+v)
+	}
+
+	// Let's parse the complete command
+	file, err := syntax.NewParser().Parse(strings.NewReader(command), "")
+	if err != nil {
+		return errors.Wrap(err, "parse shell command")
+	}
+
+	// Get current working directory
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// Create shell runner
+	r, err := interp.New(interp.Dir(pwd), interp.StdIO(os.Stdin, stdout, stderr), interp.Env(expand.ListEnviron(env...)))
+	if err != nil {
+		return errors.Wrap(err, "create shell runner")
+	}
+
+	// Run command
+	err = r.Run(context.Background(), file)
+	if err != nil && err != interp.ShellExitStatus(0) {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Changes
- Added `vars[*].value`, which is a shortcut for using `vars[*].default` and `vars[*].source: none`
- Deprecated the `--dependencies` flag for `devspace purge`, use instead the new flag `--all` and `-a`
- You can now use `devspace run dependency1.command` instead of `devspace --dependency dependency1 run command`
- You can now define shell commands in vars by leaving out the `args`:
```yaml
vars:
- name: FROM_CMD
  command: "echo 123"
```
- Added `commands[*].args` that if defined will not execute the command in a golang shell and rather executes the command directly