### PR TITLE
Add option to display helm output during install/upgrade

### DIFF
--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -594,6 +594,7 @@ type HelmConfig struct {
 	ValuesFiles      []string                    `yaml:"valuesFiles,omitempty" json:"valuesFiles,omitempty"`
 	ReplaceImageTags *bool                       `yaml:"replaceImageTags,omitempty" json:"replaceImageTags,omitempty"`
 	Wait             bool                        `yaml:"wait,omitempty" json:"wait,omitempty"`
+	Output           bool                        `yaml:"output,omitempty" json:"output,omitempty"`
 	Timeout          *int64                      `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Force            bool                        `yaml:"force,omitempty" json:"force,omitempty"`
 	Atomic           bool                        `yaml:"atomic,omitempty" json:"atomic,omitempty"`

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -594,7 +594,7 @@ type HelmConfig struct {
 	ValuesFiles      []string                    `yaml:"valuesFiles,omitempty" json:"valuesFiles,omitempty"`
 	ReplaceImageTags *bool                       `yaml:"replaceImageTags,omitempty" json:"replaceImageTags,omitempty"`
 	Wait             bool                        `yaml:"wait,omitempty" json:"wait,omitempty"`
-	Output           bool                        `yaml:"output,omitempty" json:"output,omitempty"`
+	DisplayOutput    bool                        `yaml:"displayOutput,omitempty" json:"output,omitempty"`
 	Timeout          *int64                      `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Force            bool                        `yaml:"force,omitempty" json:"force,omitempty"`
 	Atomic           bool                        `yaml:"atomic,omitempty" json:"atomic,omitempty"`

--- a/pkg/devspace/config/versions/v1beta9/schema.go
+++ b/pkg/devspace/config/versions/v1beta9/schema.go
@@ -606,6 +606,7 @@ type HelmConfig struct {
 	ValuesFiles      []string                    `yaml:"valuesFiles,omitempty" json:"valuesFiles,omitempty"`
 	ReplaceImageTags *bool                       `yaml:"replaceImageTags,omitempty" json:"replaceImageTags,omitempty"`
 	Wait             bool                        `yaml:"wait,omitempty" json:"wait,omitempty"`
+	Output           bool                        `yaml:"output,omitempty" json:"output,omitempty"`
 	Timeout          *int64                      `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Force            bool                        `yaml:"force,omitempty" json:"force,omitempty"`
 	Atomic           bool                        `yaml:"atomic,omitempty" json:"atomic,omitempty"`

--- a/pkg/devspace/config/versions/v1beta9/schema.go
+++ b/pkg/devspace/config/versions/v1beta9/schema.go
@@ -606,7 +606,7 @@ type HelmConfig struct {
 	ValuesFiles      []string                    `yaml:"valuesFiles,omitempty" json:"valuesFiles,omitempty"`
 	ReplaceImageTags *bool                       `yaml:"replaceImageTags,omitempty" json:"replaceImageTags,omitempty"`
 	Wait             bool                        `yaml:"wait,omitempty" json:"wait,omitempty"`
-	Output           bool                        `yaml:"output,omitempty" json:"output,omitempty"`
+	DisplayOutput    bool                        `yaml:"displayOutput,omitempty" json:"output,omitempty"`
 	Timeout          *int64                      `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Force            bool                        `yaml:"force,omitempty" json:"force,omitempty"`
 	Atomic           bool                        `yaml:"atomic,omitempty" json:"atomic,omitempty"`

--- a/pkg/devspace/helm/v3/client.go
+++ b/pkg/devspace/helm/v3/client.go
@@ -129,8 +129,8 @@ func (c *client) InstallChart(releaseName string, releaseNamespace string, value
 	args = append(args, helmConfig.UpgradeArgs...)
 	output, err := c.genericHelm.Exec(args, helmConfig)
 
-	if helmConfig.Output {
-		c.log.Infof("Helm Output '%s'", output)
+	if helmConfig.DisplayOutput {
+		c.log.Write(output)
 	}
 
 	if err != nil {

--- a/pkg/devspace/helm/v3/client.go
+++ b/pkg/devspace/helm/v3/client.go
@@ -1,6 +1,10 @@
 package v3
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
+
 	"github.com/ghodss/yaml"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/helm/generic"
@@ -8,9 +12,6 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/util/command"
 	"github.com/loft-sh/devspace/pkg/util/log"
-	"os"
-	"path/filepath"
-	"strconv"
 
 	"runtime"
 	"strings"
@@ -126,7 +127,12 @@ func (c *client) InstallChart(releaseName string, releaseNamespace string, value
 	}
 
 	args = append(args, helmConfig.UpgradeArgs...)
-	_, err = c.genericHelm.Exec(args, helmConfig)
+	output, err := c.genericHelm.Exec(args, helmConfig)
+
+	if helmConfig.Output {
+		c.log.Infof("Helm Output '%s'", output)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/helm/v3/client.go
+++ b/pkg/devspace/helm/v3/client.go
@@ -66,7 +66,7 @@ func (c *client) IsValidHelm(path string) (bool, error) {
 	return strings.Contains(string(out), `:"v3.`), nil
 }
 
-// InstallChart installs the given chart via helm v2
+// InstallChart installs the given chart via helm v3
 func (c *client) InstallChart(releaseName string, releaseNamespace string, values map[interface{}]interface{}, helmConfig *latest.HelmConfig) (*types.Release, error) {
 	valuesFile, err := c.genericHelm.WriteValues(values)
 	if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement
/kind feature



**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves https://github.com/loft-sh/devspace/issues/1419
This adds an option in the helm config to enable output. When set to true this allows to show the output from helm install/upgrade during a deploy.

Since this is technically backward compatible I added it to the current schema but I'm not sure if this actually warrants a new version.

I'm also aware this is missing the documentation part. I wanted to get feedback on the implementation/interface first.

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  

Change should be backward compatible. The field is omitted by default and the behaviour is the same as currently if not provided.
This will require addition to the documentation.


**Does this pull request add new dependencies?**  

No

**What else do we need to know?**  

Example of what the yaml and the output looks like

```
- name: my-api
  helm:
    chart:
      name: ../helm-charts/charts/my-chart
    output: true
    values:
    valuesFiles:
    - ./values.yaml
```

```
[info]   Execute 'helm upgrade my-api ../helm-charts/charts/my-chart --namespace default --values /var/folders/d4/6jnt6_p51mxgcnhjm9b6fzm80000gp/T/156734643
 --install --kube-context context'
[info]   Helm Output 'Release "my-api" has been upgraded. Happy Helming!
NAME: my-api
LAST DEPLOYED: Fri Apr 23 13:21:23 2021
NAMESPACE: default
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
Thank you for installing my-chart.

Your release is named my-api.

To learn more about the release, try:

  $ helm status my-api
  $ helm get all my-api
```


