### PR TITLE
feat: add imageSelector

### DIFF
--- a/cmd/list/ports.go
+++ b/cmd/list/ports.go
@@ -62,6 +62,7 @@ func (cmd *portsCmd) RunListPort(f factory.Factory, cobraCmd *cobra.Command, arg
 
 	headerColumnNames := []string{
 		"Image",
+		"ImageSelector",
 		"LabelSelector",
 		"Ports (Local:Remote)",
 	}
@@ -97,6 +98,7 @@ func (cmd *portsCmd) RunListPort(f factory.Factory, cobraCmd *cobra.Command, arg
 
 		portForwards = append(portForwards, []string{
 			value.ImageName,
+			value.ImageSelector,
 			selector,
 			portMappings,
 		})

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -130,7 +130,7 @@ func (cmd *LogsCmd) RunLogs(f factory.Factory, plugins []plugin.Metadata, cobraC
 }
 
 func getImageSelector(client kubectl.Client, configLoader loader.ConfigLoader, configOptions *loader.ConfigOptions, image string, log log.Logger) ([]imageselector.ImageSelector, error) {
-	var imageSelector []imageselector.ImageSelector
+	var imageSelectors []imageselector.ImageSelector
 	if image != "" {
 		if configLoader.Exists() == false {
 			return nil, errors.New(message.ConfigNotFound)
@@ -148,13 +148,15 @@ func getImageSelector(client kubectl.Client, configLoader loader.ConfigLoader, c
 			log.Warnf("Error resolving dependencies: %v", err)
 		}
 
-		imageSelector, err = imageselector.Resolve(image, config, resolved)
+		imageSelector, err := imageselector.Resolve(image, config, resolved)
 		if err != nil {
 			return nil, err
-		} else if len(imageSelector) == 0 {
+		} else if imageSelector == nil {
 			return nil, fmt.Errorf("couldn't find an image with name %s in devspace config", image)
 		}
+
+		imageSelectors = append(imageSelectors, *imageSelector)
 	}
 
-	return imageSelector, nil
+	return imageSelectors, nil
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency"
+	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/plugin"
 	"github.com/loft-sh/devspace/pkg/devspace/services"
@@ -144,6 +145,14 @@ func (cmd *RestartCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCm
 		if err != nil {
 			return err
 		} else if imageSelector != nil {
+			options.ImageSelector = append(options.ImageSelector, *imageSelector)
+		}
+		if syncPath.ImageSelector != "" {
+			imageSelector, err := util.ResolveImageAsImageSelector(syncPath.ImageSelector, configInterface, dep)
+			if err != nil {
+				return err
+			}
+
 			options.ImageSelector = append(options.ImageSelector, *imageSelector)
 		}
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -139,7 +139,13 @@ func (cmd *RestartCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCm
 
 		// create target selector options
 		options := targetselector.NewOptionsFromFlags("", "", cmd.Namespace, "", cmd.Pick).ApplyConfigParameter(syncPath.LabelSelector, syncPath.Namespace, syncPath.ContainerName, "")
-		options.ImageSelector, err = imageselector.Resolve(syncPath.ImageName, configInterface, dep)
+		options.ImageSelector = []imageselector.ImageSelector{}
+		imageSelector, err := imageselector.Resolve(syncPath.ImageName, configInterface, dep)
+		if err != nil {
+			return err
+		} else if imageSelector != nil {
+			options.ImageSelector = append(options.ImageSelector, *imageSelector)
+		}
 
 		err = restartContainer(client, options, cmd.log)
 		if err != nil {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -203,6 +203,8 @@ func (cmd *SyncCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *
 				selector := ""
 				if sc.ImageName != "" {
 					selector = "image: " + sc.ImageName
+				} else if sc.ImageSelector != "" {
+					selector = "img-selector: " + sc.ImageSelector
 				} else if len(sc.LabelSelector) > 0 {
 					selector = "selector: " + labels.Set(sc.LabelSelector).String()
 				}
@@ -246,6 +248,7 @@ func (cmd *SyncCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd *
 		if options.LabelSelector != "" || options.Pod != "" {
 			loadedSyncConfig.LabelSelector = nil
 			loadedSyncConfig.ImageName = ""
+			loadedSyncConfig.ImageSelector = ""
 		}
 		if options.Namespace != "" {
 			loadedSyncConfig.Namespace = ""

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/upgrade"
 )
 
-var version string = "v0.0.0"
+var version string = ""
 
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -692,6 +692,7 @@ type DevConfig struct {
 // pod patches.
 type ReplacePod struct {
 	ImageName     string            `yaml:"imageName,omitempty" json:"imageName,omitempty"`
+	ImageSelector string            `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	LabelSelector map[string]string `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`
 	ContainerName string            `yaml:"containerName,omitempty" json:"containerName,omitempty"`
 	Namespace     string            `yaml:"namespace,omitempty" json:"namespace,omitempty"`
@@ -702,6 +703,7 @@ type ReplacePod struct {
 
 // PortForwardingConfig defines the ports for a port forwarding to a DevSpace
 type PortForwardingConfig struct {
+	ImageSelector string            `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	ImageName     string            `yaml:"imageName,omitempty" json:"imageName,omitempty"`
 	LabelSelector map[string]string `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`
 	ContainerName string            `yaml:"containerName,omitempty" json:"containerName,omitempty"`
@@ -728,6 +730,7 @@ type OpenConfig struct {
 
 // SyncConfig defines the paths for a SyncFolder
 type SyncConfig struct {
+	ImageSelector        string               `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	ImageName            string               `yaml:"imageName,omitempty" json:"imageName,omitempty"`
 	LabelSelector        map[string]string    `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`
 	ContainerName        string               `yaml:"containerName,omitempty" json:"containerName,omitempty"`
@@ -867,6 +870,7 @@ type InteractiveImageConfig struct {
 
 // Terminal describes the terminal options
 type Terminal struct {
+	ImageSelector string            `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	ImageName     string            `yaml:"imageName,omitempty" json:"imageName,omitempty"`
 	LabelSelector map[string]string `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`
 	ContainerName string            `yaml:"containerName,omitempty" json:"containerName,omitempty"`
@@ -880,6 +884,7 @@ type Terminal struct {
 
 // PodPatch will patch a pod's owning ReplicaSet, Deployment or StatefulSet with the givens patches or image
 type PodPatch struct {
+	ImageSelector string            `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	ImageName     string            `yaml:"imageName,omitempty" json:"imageName,omitempty"`
 	LabelSelector map[string]string `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`
 	ContainerName string            `yaml:"containerName,omitempty" json:"containerName,omitempty"`
@@ -1016,6 +1021,7 @@ type HookContainer struct {
 	LabelSelector map[string]string `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`
 	Pod           string            `yaml:"pod,omitempty" json:"pod,omitempty"`
 	Namespace     string            `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	ImageSelector string            `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	ImageName     string            `yaml:"imageName,omitempty" json:"imageName,omitempty"`
 	ContainerName string            `yaml:"containerName,omitempty" json:"containerName,omitempty"`
 

--- a/pkg/devspace/deploy/deployer/util/replace.go
+++ b/pkg/devspace/deploy/deployer/util/replace.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	config2 "github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/generated"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
@@ -136,6 +137,27 @@ func resolveImage(value string, config config2.Config, dependencies []types.Depe
 
 	// not found, return the initial value
 	return false, shouldRedeploy, value, nil
+}
+
+func ResolveImage(imageSelector string, config config2.Config, dependencies []types.Dependency) (string, error) {
+	_, image, err := Replace(imageSelector, config, dependencies, map[string]string{})
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v", image), nil
+}
+
+func ResolveImageAsImageSelector(imageSelector string, config config2.Config, dependencies []types.Dependency) (*imageselector.ImageSelector, error) {
+	image, err := ResolveImage(imageSelector, config, dependencies)
+	if err != nil {
+		return nil, err
+	}
+
+	return &imageselector.ImageSelector{
+		ImageSelector: imageSelector,
+		Image:         image,
+	}, nil
 }
 
 func Replace(value string, config config2.Config, dependencies []types.Dependency, builtImages map[string]string) (bool, interface{}, error) {

--- a/pkg/devspace/deploy/deployer/util/replace.go
+++ b/pkg/devspace/deploy/deployer/util/replace.go
@@ -57,7 +57,7 @@ func Match(key, value string, keys map[string]bool) bool {
 func resolveImage(value string, config config2.Config, dependencies []types.Dependency, builtImages map[string]string, tryImageKey, onlyImage, onlyTag bool) (bool, bool, string, error) {
 	resolvedImage := value
 	if tryImageKey {
-		selector, err := imageselector.ResolveSingle(value, config, dependencies)
+		selector, err := imageselector.Resolve(value, config, dependencies)
 		if err == nil && selector != nil {
 			resolvedImage = selector.Image
 			if selector.Dependency != nil {

--- a/pkg/devspace/hook/hook.go
+++ b/pkg/devspace/hook/hook.go
@@ -256,7 +256,7 @@ func hookName(hook *latest.HookConfig) string {
 		if hook.Args == nil {
 			return hook.Command
 		}
-		
+
 		return fmt.Sprintf("%s %s", hook.Command, strings.Join(hook.Args, " "))
 	}
 	if hook.Upload != nil && hook.Where.Container != nil {
@@ -277,6 +277,9 @@ func hookName(hook *latest.HookConfig) string {
 		}
 		if hook.Where.Container.ImageName != "" {
 			return fmt.Sprintf("copy %s to imageName %s", localPath, hook.Where.Container.ImageName)
+		}
+		if hook.Where.Container.ImageSelector != "" {
+			return fmt.Sprintf("copy %s to image %s", localPath, hook.Where.Container.ImageSelector)
 		}
 
 		return fmt.Sprintf("copy %s to %s", localPath, containerPath)
@@ -300,6 +303,9 @@ func hookName(hook *latest.HookConfig) string {
 		if hook.Where.Container.ImageName != "" {
 			return fmt.Sprintf("download from imageName %s to %s", hook.Where.Container.ImageName, localPath)
 		}
+		if hook.Where.Container.ImageSelector != "" {
+			return fmt.Sprintf("download from image %s to %s", hook.Where.Container.ImageSelector, localPath)
+		}
 
 		return fmt.Sprintf("download from container:%s to local:%s", containerPath, localPath)
 	}
@@ -313,6 +319,9 @@ func hookName(hook *latest.HookConfig) string {
 		if hook.Where.Container.ImageName != "" {
 			return fmt.Sprintf("logs from imageName %s", hook.Where.Container.ImageName)
 		}
+		if hook.Where.Container.ImageSelector != "" {
+			return fmt.Sprintf("logs from image %s", hook.Where.Container.ImageSelector)
+		}
 
 		return fmt.Sprintf("logs from first container found")
 	}
@@ -325,6 +334,9 @@ func hookName(hook *latest.HookConfig) string {
 		}
 		if hook.Where.Container.ImageName != "" {
 			return fmt.Sprintf("wait for imageName %s", hook.Where.Container.ImageName)
+		}
+		if hook.Where.Container.ImageSelector != "" {
+			return fmt.Sprintf("wait for image %s", hook.Where.Container.ImageSelector)
 		}
 
 		return fmt.Sprintf("wait for everything")

--- a/pkg/devspace/hook/remote_hook.go
+++ b/pkg/devspace/hook/remote_hook.go
@@ -53,9 +53,12 @@ func (r *remoteHook) Execute(ctx Context, hook *latest.HookConfig, config config
 			return errors.Errorf("Cannot execute hook '%s': config is not loaded", ansi.Color(hookName(hook), "white+b"))
 		}
 
-		imageSelector, err = imageselector.Resolve(hook.Where.Container.ImageName, config, dependencies)
+		imageSelectorFromConfig, err := imageselector.Resolve(hook.Where.Container.ImageName, config, dependencies)
 		if err != nil {
 			return err
+		}
+		if imageSelectorFromConfig != nil {
+			imageSelector = append(imageSelector, *imageSelectorFromConfig)
 		}
 	}
 

--- a/pkg/devspace/hook/remote_hook.go
+++ b/pkg/devspace/hook/remote_hook.go
@@ -5,6 +5,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
+	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
@@ -45,24 +46,35 @@ func (r *remoteHook) Execute(ctx Context, hook *latest.HookConfig, config config
 	}
 
 	var (
-		imageSelector []imageselector.ImageSelector
-		err           error
+		imageSelectors []imageselector.ImageSelector
+		err            error
 	)
-	if hook.Where.Container.ImageName != "" {
+	if hook.Where.Container.ImageName != "" || hook.Where.Container.ImageSelector != "" {
 		if config == nil || config.Generated() == nil {
 			return errors.Errorf("Cannot execute hook '%s': config is not loaded", ansi.Color(hookName(hook), "white+b"))
 		}
 
-		imageSelectorFromConfig, err := imageselector.Resolve(hook.Where.Container.ImageName, config, dependencies)
-		if err != nil {
-			return err
+		if hook.Where.Container.ImageName != "" {
+			imageSelectorFromConfig, err := imageselector.Resolve(hook.Where.Container.ImageName, config, dependencies)
+			if err != nil {
+				return err
+			}
+			if imageSelectorFromConfig != nil {
+				imageSelectors = append(imageSelectors, *imageSelectorFromConfig)
+			}
 		}
-		if imageSelectorFromConfig != nil {
-			imageSelector = append(imageSelector, *imageSelectorFromConfig)
+
+		if hook.Where.Container.ImageSelector != "" {
+			imageSelector, err := util.ResolveImageAsImageSelector(hook.Where.Container.ImageSelector, config, dependencies)
+			if err != nil {
+				return err
+			}
+
+			imageSelectors = append(imageSelectors, *imageSelector)
 		}
 	}
 
-	executed, err := r.execute(ctx, hook, imageSelector, log)
+	executed, err := r.execute(ctx, hook, imageSelectors, log)
 	if err != nil {
 		return err
 	} else if executed == false {

--- a/pkg/devspace/hook/wait.go
+++ b/pkg/devspace/hook/wait.go
@@ -39,9 +39,13 @@ func (r *waitHook) Execute(ctx Context, hook *latest.HookConfig, config config.C
 			return errors.Errorf("Cannot execute hook '%s': config is not loaded", ansi.Color(hookName(hook), "white+b"))
 		}
 
-		imageSelector, err = imageselector.Resolve(hook.Where.Container.ImageName, config, dependencies)
+		imageSelectorFromConfig, err := imageselector.Resolve(hook.Where.Container.ImageName, config, dependencies)
 		if err != nil {
 			return err
+		}
+
+		if imageSelectorFromConfig != nil {
+			imageSelector = append(imageSelector, *imageSelectorFromConfig)
 		}
 	}
 

--- a/pkg/devspace/hook/wait.go
+++ b/pkg/devspace/hook/wait.go
@@ -5,6 +5,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
+	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
@@ -31,25 +32,35 @@ func (r *waitHook) Execute(ctx Context, hook *latest.HookConfig, config config.C
 	}
 
 	var (
-		imageSelector []imageselector.ImageSelector
-		err           error
+		imageSelectors []imageselector.ImageSelector
+		err            error
 	)
-	if hook.Where.Container.ImageName != "" {
+	if hook.Where.Container.ImageName != "" || hook.Where.Container.ImageSelector != "" {
 		if config == nil || config.Generated() == nil {
 			return errors.Errorf("Cannot execute hook '%s': config is not loaded", ansi.Color(hookName(hook), "white+b"))
 		}
 
-		imageSelectorFromConfig, err := imageselector.Resolve(hook.Where.Container.ImageName, config, dependencies)
-		if err != nil {
-			return err
+		if hook.Where.Container.ImageName != "" {
+			imageSelectorFromConfig, err := imageselector.Resolve(hook.Where.Container.ImageName, config, dependencies)
+			if err != nil {
+				return err
+			}
+			if imageSelectorFromConfig != nil {
+				imageSelectors = append(imageSelectors, *imageSelectorFromConfig)
+			}
 		}
 
-		if imageSelectorFromConfig != nil {
-			imageSelector = append(imageSelector, *imageSelectorFromConfig)
+		if hook.Where.Container.ImageSelector != "" {
+			imageSelector, err := util.ResolveImageAsImageSelector(hook.Where.Container.ImageSelector, config, dependencies)
+			if err != nil {
+				return err
+			}
+
+			imageSelectors = append(imageSelectors, *imageSelector)
 		}
 	}
 
-	err = r.execute(ctx, hook, imageSelector, log)
+	err = r.execute(ctx, hook, imageSelectors, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/devspace/services/log_manager.go
+++ b/pkg/devspace/services/log_manager.go
@@ -53,21 +53,21 @@ func NewLogManager(client kubectl.Client, config config.Config, dependencies []t
 	imageSelector := []imageselector.ImageSelector{}
 	if c.Dev.Logs != nil && c.Dev.Logs.Images != nil {
 		for _, configImageName := range c.Dev.Logs.Images {
-			selectors, err := imageselector.Resolve(configImageName, config, dependencies)
+			selector, err := imageselector.Resolve(configImageName, config, dependencies)
 			if err != nil {
 				return nil, err
+			} else if selector != nil {
+				imageSelector = append(imageSelector, *selector)
 			}
-
-			imageSelector = append(imageSelector, selectors...)
 		}
 	} else {
 		for configImageName := range c.Images {
-			selectors, err := imageselector.Resolve(configImageName, config, dependencies)
+			selector, err := imageselector.Resolve(configImageName, config, dependencies)
 			if err != nil {
 				return nil, err
+			} else if selector != nil {
+				imageSelector = append(imageSelector, *selector)
 			}
-
-			imageSelector = append(imageSelector, selectors...)
 		}
 	}
 

--- a/pkg/devspace/services/podreplace/podreplace.go
+++ b/pkg/devspace/services/podreplace/podreplace.go
@@ -335,6 +335,9 @@ func replace(ctx context.Context, client kubectl.Client, pod *kubectl.SelectedPo
 	if replacePod.ImageName != "" {
 		copiedPod.Labels[kubectl.ImageNameLabel] = replacePod.ImageName
 	}
+	if replacePod.ImageSelector != "" {
+		copiedPod.Labels[kubectl.ImageSelectorLabel] = hash.String(replacePod.ImageSelector)[:32]
+	}
 	copiedPod.Annotations[kubectl.MatchedContainerAnnotation] = pod.Container.Name
 	copiedPod.Annotations[ParentHashAnnotation] = parentHash
 	copiedPod.Annotations[ReplaceConfigHashAnnotation] = configHash
@@ -456,11 +459,10 @@ func hashParentPodSpec(obj runtime.Object, config config.Config, dependencies []
 }
 
 func replaceImageInPodSpec(podSpec *corev1.PodSpec, config config.Config, dependencies []dependencytypes.Dependency, replacePod *latest.ReplacePod) error {
-	_, image, err := util.Replace(replacePod.ReplaceImage, config, dependencies, map[string]string{})
+	imageStr, err := util.ResolveImage(replacePod.ReplaceImage, config, dependencies)
 	if err != nil {
 		return err
 	}
-	imageStr := fmt.Sprintf("%v", image)
 
 	// either replace by labelSelector & containerName
 	// or by resolved image name
@@ -481,12 +483,20 @@ func replaceImageInPodSpec(podSpec *corev1.PodSpec, config config.Config, depend
 				break
 			}
 		}
-	} else {
-		imageSelector, err := imageselector.Resolve(replacePod.ImageName, config, dependencies)
-		if err != nil {
-			return err
-		} else if imageSelector == nil {
-			return fmt.Errorf("cannot find image name: %#+v", replacePod.ImageName)
+	} else if replacePod.ImageName != "" || replacePod.ImageSelector != "" {
+		var imageSelector *imageselector.ImageSelector
+		if replacePod.ImageName != "" {
+			imageSelector, err = imageselector.Resolve(replacePod.ImageName, config, dependencies)
+			if err != nil {
+				return err
+			} else if imageSelector == nil {
+				return fmt.Errorf("cannot find image name: %#+v", replacePod.ImageName)
+			}
+		} else if replacePod.ImageSelector != "" {
+			imageSelector, err = util.ResolveImageAsImageSelector(replacePod.ImageSelector, config, dependencies)
+			if err != nil {
+				return err
+			}
 		}
 
 		// exchange image name
@@ -633,12 +643,14 @@ func findSingleReplacedPod(ctx context.Context, client kubectl.Client, replacePo
 	}
 	if replacePod.ImageName != "" {
 		labelSelector[kubectl.ImageNameLabel] = replacePod.ImageName
+	} else if replacePod.ImageSelector != "" {
+		labelSelector[kubectl.ImageSelectorLabel] = hash.String(replacePod.ImageSelector)[:32]
 	} else if len(replacePod.LabelSelector) > 0 {
 		for k, v := range replacePod.LabelSelector {
 			labelSelector[k] = v
 		}
 	} else {
-		return nil, fmt.Errorf("imageName or labelSelector need to be defined")
+		return nil, fmt.Errorf("imageName, imageSelector or labelSelector need to be defined")
 	}
 
 	// create selector
@@ -673,6 +685,14 @@ func findSingleReplaceablePodParent(ctx context.Context, client kubectl.Client, 
 	if err != nil {
 		return nil, nil, err
 	} else if imageSelector != nil {
+		targetOptions.ImageSelector = append(targetOptions.ImageSelector, *imageSelector)
+	}
+	if replacePod.ImageSelector != "" {
+		imageSelector, err := util.ResolveImageAsImageSelector(replacePod.ImageSelector, config, dependencies)
+		if err != nil {
+			return nil, nil, err
+		}
+		
 		targetOptions.ImageSelector = append(targetOptions.ImageSelector, *imageSelector)
 	}
 

--- a/pkg/devspace/services/port_forwarding.go
+++ b/pkg/devspace/services/port_forwarding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/loft-sh/devspace/pkg/devspace/config/generated"
+	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
 	"strconv"
 	"strings"
@@ -50,6 +51,14 @@ func (serviceClient *client) startForwarding(cache *generated.CacheConfig, portF
 	if err != nil {
 		return err
 	} else if imageSelector != nil {
+		options.ImageSelector = append(options.ImageSelector, *imageSelector)
+	}
+	if portForwarding.ImageSelector != "" {
+		imageSelector, err := util.ResolveImageAsImageSelector(portForwarding.ImageSelector, serviceClient.config, serviceClient.dependencies)
+		if err != nil {
+			return err
+		}
+
 		options.ImageSelector = append(options.ImageSelector, *imageSelector)
 	}
 	options.WaitingStrategy = targetselector.NewUntilNewestRunningWaitingStrategy(time.Second * 2)

--- a/pkg/devspace/services/port_forwarding.go
+++ b/pkg/devspace/services/port_forwarding.go
@@ -45,9 +45,12 @@ func (serviceClient *client) startForwarding(cache *generated.CacheConfig, portF
 	// apply config & set image selector
 	options := targetselector.NewEmptyOptions().ApplyConfigParameter(portForwarding.LabelSelector, portForwarding.Namespace, "", "")
 	options.AllowPick = false
-	options.ImageSelector, err = imageselector.Resolve(portForwarding.ImageName, serviceClient.config, serviceClient.dependencies)
+	options.ImageSelector = []imageselector.ImageSelector{}
+	imageSelector, err := imageselector.Resolve(portForwarding.ImageName, serviceClient.config, serviceClient.dependencies)
 	if err != nil {
 		return err
+	} else if imageSelector != nil {
+		options.ImageSelector = append(options.ImageSelector, *imageSelector)
 	}
 	options.WaitingStrategy = targetselector.NewUntilNewestRunningWaitingStrategy(time.Second * 2)
 	options.SkipInitContainers = true

--- a/pkg/devspace/services/reverse_port_forwarding.go
+++ b/pkg/devspace/services/reverse_port_forwarding.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/loft-sh/devspace/pkg/devspace/config/generated"
+	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/devspace/tunnel"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
 	"io"
@@ -49,6 +50,14 @@ func (serviceClient *client) startReversePortForwarding(cache *generated.CacheCo
 	if err != nil {
 		return err
 	} else if imageSelector != nil {
+		options.ImageSelector = append(options.ImageSelector, *imageSelector)
+	}
+	if portForwarding.ImageSelector != "" {
+		imageSelector, err := util.ResolveImageAsImageSelector(portForwarding.ImageSelector, serviceClient.config, serviceClient.dependencies)
+		if err != nil {
+			return err
+		}
+
 		options.ImageSelector = append(options.ImageSelector, *imageSelector)
 	}
 	options.WaitingStrategy = targetselector.NewUntilNewestRunningWaitingStrategy(time.Second * 2)

--- a/pkg/devspace/services/reverse_port_forwarding.go
+++ b/pkg/devspace/services/reverse_port_forwarding.go
@@ -44,9 +44,12 @@ func (serviceClient *client) startReversePortForwarding(cache *generated.CacheCo
 	// apply config & set image selector
 	options := targetselector.NewEmptyOptions().ApplyConfigParameter(portForwarding.LabelSelector, portForwarding.Namespace, portForwarding.ContainerName, "")
 	options.AllowPick = false
-	options.ImageSelector, err = imageselector.Resolve(portForwarding.ImageName, serviceClient.config, serviceClient.dependencies)
+	options.ImageSelector = []imageselector.ImageSelector{}
+	imageSelector, err := imageselector.Resolve(portForwarding.ImageName, serviceClient.config, serviceClient.dependencies)
 	if err != nil {
 		return err
+	} else if imageSelector != nil {
+		options.ImageSelector = append(options.ImageSelector, *imageSelector)
 	}
 	options.WaitingStrategy = targetselector.NewUntilNewestRunningWaitingStrategy(time.Second * 2)
 	options.SkipInitContainers = true

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/loft-sh/devspace/assets"
+	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/util/hash"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
@@ -165,6 +166,14 @@ func (serviceClient *client) startSyncClient(options *startClientOptions, log lo
 	if err != nil {
 		return err
 	} else if imageSelector != nil {
+		options.TargetOptions.ImageSelector = append(options.TargetOptions.ImageSelector, *imageSelector)
+	}
+	if syncConfig.ImageSelector != "" {
+		imageSelector, err := util.ResolveImageAsImageSelector(syncConfig.ImageSelector, serviceClient.config, serviceClient.dependencies)
+		if err != nil {
+			return err
+		}
+
 		options.TargetOptions.ImageSelector = append(options.TargetOptions.ImageSelector, *imageSelector)
 	}
 

--- a/pkg/devspace/services/sync.go
+++ b/pkg/devspace/services/sync.go
@@ -160,9 +160,12 @@ func (serviceClient *client) startSyncClient(options *startClientOptions, log lo
 		}
 	}
 
-	options.TargetOptions.ImageSelector, err = imageselector.Resolve(syncConfig.ImageName, serviceClient.config, serviceClient.dependencies)
+	options.TargetOptions.ImageSelector = []imageselector.ImageSelector{}
+	imageSelector, err := imageselector.Resolve(syncConfig.ImageName, serviceClient.config, serviceClient.dependencies)
 	if err != nil {
 		return err
+	} else if imageSelector != nil {
+		options.TargetOptions.ImageSelector = append(options.TargetOptions.ImageSelector, *imageSelector)
 	}
 
 	log.StartWait("Sync: Waiting for pods...")

--- a/pkg/util/imageselector/imageselector.go
+++ b/pkg/util/imageselector/imageselector.go
@@ -13,6 +13,8 @@ import (
 type ImageSelector struct {
 	// ConfigImageName is the image config name (from images.*)
 	ConfigImageName string
+	// ImageSelector is the original image selector string
+	ImageSelector string
 	// Image is the resolved docker image inclusive tag
 	Image string
 	// Dependency is the dependency this image selector was loaded from


### PR DESCRIPTION
- New field `imageSelector` that allows you to select containers for sync, podReplace, port-forwarding etc. by the container image instead of the config name in `images`. This makes it easier for certain use cases as you can now omit the `images` section sometimes completely:
```yaml
version: v1beta10
vars:
  - name: IMAGE
    value: registry.com/production:latest
deployments:
  - name: my-chart
    helm:
      chart:
        name: my-application
      values:
        image: ${IMAGE}
dev:
  terminal:
    imageSelector: ${IMAGE}
  replacePods:
    - imageSelector: ${IMAGE}
      replaceImage: registry.com/dev:latest
      patches:
        - op: replace
          path: spec.containers[0].workingDir
          value: /app
        - op: replace
          path: spec.containers[0].command
          value: ["sleep"]
        - op: replace
          path: spec.containers[0].args
          value: ["9999999999"]
  ports:
    - imageSelector: ${IMAGE}
      forward:
        - port: 3000
  sync:
    - imageSelector: ${IMAGE}
      uploadExcludePaths:
        - node_modules
```