### PR TITLE
feat: scale up sets on devspace reset pods

### DIFF
--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -139,9 +139,18 @@ func (cmd *PurgeCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 
 	// Only purge if we don't specify dependency
 	if len(cmd.Dependency) == 0 {
+		// Resolve dependencies
+		dep, err := f.NewDependencyManager(configInterface, client, configOptions, cmd.log).ResolveAll(dependency.ResolveOptions{
+			UpdateDependencies: false,
+			Verbose:            false,
+		})
+		if err != nil {
+			cmd.log.Warnf("Error resolving dependencies: %v", err)
+		}
+
 		// Reset replaced pods
 		if len(configInterface.Config().Dev.ReplacePods) > 0 {
-			reset.ResetPods(client, configInterface, cmd.log)
+			reset.ResetPods(client, configInterface, dep, cmd.log)
 		}
 
 		deployments := []string{}

--- a/examples/replace-pod/devspace.yaml
+++ b/examples/replace-pod/devspace.yaml
@@ -1,9 +1,7 @@
 version: v1beta10
-images:
-  backend:
-    image: john/devbackend
-    build:
-      disabled: true
+vars:
+  - name: IMAGE
+    value: john/devbackend
 deployments:
   - name: app-backend
     helm:
@@ -11,10 +9,10 @@ deployments:
       values:
         containers:
           - name: container-0
-            image: john/devbackend
+            image: ${IMAGE}
 dev:
   replacePods:
-    - imageName: backend
+    - imageSelector: ${IMAGE}
       replaceImage: ubuntu:latest
       patches:
         - op: add
@@ -27,4 +25,4 @@ dev:
           path: spec.containers[0].workingDir
           value: "/workdir"
   terminal:
-    imageName: backend
+    imageSelector: ${IMAGE}

--- a/pkg/util/imageselector/imageselector.go
+++ b/pkg/util/imageselector/imageselector.go
@@ -114,9 +114,9 @@ func CompareImageNames(selector ImageSelector, image2 string) bool {
 		}
 
 		return image1 == image2
-	} else {
-		return tagStrippedImage1 == tagStrippedImage2
 	}
+
+	return tagStrippedImage1 == tagStrippedImage2
 }
 
 // GetStrippedDockerImageName returns a tag stripped image name and checks if it's a valid image name


### PR DESCRIPTION
### Changes
- `devspace reset pods` will now reset scaled down deployments, statefulsets & replicasets even though no resettable pod could be found 