### PR TITLE
fix: validate vars

### DIFF
--- a/pkg/devspace/config/loader/loader.go
+++ b/pkg/devspace/config/loader/loader.go
@@ -259,6 +259,12 @@ func (l *configLoader) parseConfig(rawConfig map[interface{}]interface{}, parser
 		return nil, nil, nil, err
 	}
 
+	// validate variables
+	err = validateVars(vars)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	// Delete vars from config
 	delete(copiedRawConfig, "vars")
 

--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"fmt"
 	jsonyaml "github.com/ghodss/yaml"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/helm/merge"
@@ -70,6 +71,23 @@ func validate(config *latest.Config, log log.Logger) error {
 	err = validateDependencies(config)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func validateVars(vars []*latest.Variable) error {
+	for i, v := range vars {
+		if v.Name == "" {
+			return fmt.Errorf("vars[*].name has to be specified")
+		}
+
+		// make sure is unique
+		for j, v2 := range vars {
+			if i != j && v.Name == v2.Name {
+				return fmt.Errorf("multiple definitions for variable %s found", v.Name)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Changes
- Having multiple variable definitions with the same name under `vars` throws now an error (#1466)