### PR TITLE
feat: new dependencies[*].forwardVars option

### DIFF
--- a/docs/pages/configuration/dependencies/git-repository.mdx
+++ b/docs/pages/configuration/dependencies/git-repository.mdx
@@ -10,6 +10,7 @@ import FragmentDependencyNamespace from '../../fragments/dependency-namespace.md
 import FragmentDependencyName from '../../fragments/dependency-name.mdx';
 import FragmentDependencyVars from '../../fragments/dependency-vars.mdx';
 import FragmentDependencyDev from '../../fragments/dependency-dev.mdx';
+import FragmentDependencyOverwriteVars from '../../fragments/dependency-overwrite-vars.mdx';
 
 
 ## Example
@@ -150,6 +151,10 @@ cloneArgs: []
 ### `vars`
 
 <FragmentDependencyVars/>
+
+### `overwriteVars`
+
+<FragmentDependencyOverwriteVars/>
 
 ### `dev`
 

--- a/docs/pages/configuration/dependencies/local-folder.mdx
+++ b/docs/pages/configuration/dependencies/local-folder.mdx
@@ -10,6 +10,7 @@ import FragmentDependencyNamespace from '../../fragments/dependency-namespace.md
 import FragmentDependencyName from '../../fragments/dependency-name.mdx';
 import FragmentDependencyVars from '../../fragments/dependency-vars.mdx';
 import FragmentDependencyDev from '../../fragments/dependency-dev.mdx';
+import FragmentDependencyOverwriteVars from '../../fragments/dependency-overwrite-vars.mdx';
 
 
 ## Example
@@ -78,6 +79,10 @@ dependencies:
 ### `vars`
 
 <FragmentDependencyVars/>
+
+### `overwriteVars`
+
+<FragmentDependencyOverwriteVars/>
 
 ### `dev`
 

--- a/docs/pages/fragments/config-dependencies.mdx
+++ b/docs/pages/fragments/config-dependencies.mdx
@@ -16,6 +16,7 @@ dependencies:                       # struct[]  | Array of dependencies (other p
   dev:                              # struct    | Define which dev config should be reused from a dependency
     ports: false                    # bool      | Reuse dev.ports config from the dependency
     sync: false                     # bool      | Reuse dev.sync config from the dependency
+  overwriteVars: true               # bool      | If not defined or true, will overwrite values of variables with the same name in the dependency
   vars:                             # struct[]  | Variables in the dependency config that should be overriden with the specified values 
   - name: NAME
     value: value

--- a/docs/pages/fragments/dependency-overwrite-vars.mdx
+++ b/docs/pages/fragments/dependency-overwrite-vars.mdx
@@ -1,0 +1,53 @@
+The `overwriteVars` option is optional and expects a boolean. By default, this option is enabled and overwrites all defined variables within the dependency config with the values of the variables defined in the base config. Variables that are not used or not defined within the base config aren't overwritten in the dependency config.
+
+For example:
+```yaml
+# devspace.yaml
+vars:
+- name: DEFINED_AND_USED
+  value: my-base-value
+- name: DEFINED_AND_NOT_USED
+  value: my-other-base-value
+dependencies:
+- name: dep1
+  source:
+    path: dep1
+  # If overwriteVars is not defined or true, all variables that are used within this
+  # config are passed to the dependency and will overwrite the values of variables with 
+  # the same name there. In this case only the variable DEFINED_AND_USED
+  # will be passed to the dependency, as DEFINED_AND_NOT_USED is not used within the config.
+  # overwriteVars: true
+  #
+  # If you want to pass the variable DEFINED_AND_NOT_USED to the dependency as well,
+  # you can either use it somewhere within the config or explicitly pass it to the dependency with vars.
+  # vars:
+  # - name: DEFINED_AND_NOT_USED
+  #   value: ${DEFINED_AND_NOT_USED}
+deployments:
+- name: deployment
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: ${DEFINED_AND_USED}
+```
+
+and
+
+```yaml
+# dep1/devspace.yaml
+vars:
+- name: DEFINED_AND_USED
+  value: my-dep-value
+- name: DEFINED_AND_NOT_USED
+  value: my-other-dep-value
+deployments:
+  # This will be my-other-dep-value
+- name: ${DEFINED_AND_NOT_USED}
+  helm:
+    componentChart: true
+    values:
+      containers:
+        # This will be my-base-value
+      - image: ${DEFINED_AND_USED}
+```

--- a/docs/versioned_docs/version-5.14/configuration/dependencies/git-repository.mdx
+++ b/docs/versioned_docs/version-5.14/configuration/dependencies/git-repository.mdx
@@ -10,6 +10,7 @@ import FragmentDependencyNamespace from '../../fragments/dependency-namespace.md
 import FragmentDependencyName from '../../fragments/dependency-name.mdx';
 import FragmentDependencyVars from '../../fragments/dependency-vars.mdx';
 import FragmentDependencyDev from '../../fragments/dependency-dev.mdx';
+import FragmentDependencyOverwriteVars from '../../fragments/dependency-overwrite-vars.mdx';
 
 
 ## Example
@@ -150,6 +151,10 @@ cloneArgs: []
 ### `vars`
 
 <FragmentDependencyVars/>
+
+### `overwriteVars`
+
+<FragmentDependencyOverwriteVars/>
 
 ### `dev`
 

--- a/docs/versioned_docs/version-5.14/configuration/dependencies/local-folder.mdx
+++ b/docs/versioned_docs/version-5.14/configuration/dependencies/local-folder.mdx
@@ -10,6 +10,7 @@ import FragmentDependencyNamespace from '../../fragments/dependency-namespace.md
 import FragmentDependencyName from '../../fragments/dependency-name.mdx';
 import FragmentDependencyVars from '../../fragments/dependency-vars.mdx';
 import FragmentDependencyDev from '../../fragments/dependency-dev.mdx';
+import FragmentDependencyOverwriteVars from '../../fragments/dependency-overwrite-vars.mdx';
 
 
 ## Example
@@ -78,6 +79,10 @@ dependencies:
 ### `vars`
 
 <FragmentDependencyVars/>
+
+### `overwriteVars`
+
+<FragmentDependencyOverwriteVars/>
 
 ### `dev`
 

--- a/docs/versioned_docs/version-5.14/fragments/config-dependencies.mdx
+++ b/docs/versioned_docs/version-5.14/fragments/config-dependencies.mdx
@@ -16,6 +16,7 @@ dependencies:                       # struct[]  | Array of dependencies (other p
   dev:                              # struct    | Define which dev config should be reused from a dependency
     ports: false                    # bool      | Reuse dev.ports config from the dependency
     sync: false                     # bool      | Reuse dev.sync config from the dependency
+  overwriteVars: true               # bool      | If not defined or true, will overwrite values of variables with the same name in the dependency
   vars:                             # struct[]  | Variables in the dependency config that should be overriden with the specified values 
   - name: NAME
     value: value

--- a/docs/versioned_docs/version-5.14/fragments/dependency-overwrite-vars.mdx
+++ b/docs/versioned_docs/version-5.14/fragments/dependency-overwrite-vars.mdx
@@ -1,0 +1,53 @@
+The `overwriteVars` option is optional and expects a boolean. By default, this option is enabled and overwrites all defined variables within the dependency config with the values of the variables defined in the base config. Variables that are not used or not defined within the base config aren't overwritten in the dependency config.
+
+For example:
+```yaml
+# devspace.yaml
+vars:
+- name: DEFINED_AND_USED
+  value: my-base-value
+- name: DEFINED_AND_NOT_USED
+  value: my-other-base-value
+dependencies:
+- name: dep1
+  source:
+    path: dep1
+  # If overwriteVars is not defined or true, all variables that are used within this
+  # config are passed to the dependency and will overwrite the values of variables with 
+  # the same name there. In this case only the variable DEFINED_AND_USED
+  # will be passed to the dependency, as DEFINED_AND_NOT_USED is not used within the config.
+  # overwriteVars: true
+  #
+  # If you want to pass the variable DEFINED_AND_NOT_USED to the dependency as well,
+  # you can either use it somewhere within the config or explicitly pass it to the dependency with vars.
+  # vars:
+  # - name: DEFINED_AND_NOT_USED
+  #   value: ${DEFINED_AND_NOT_USED}
+deployments:
+- name: deployment
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: ${DEFINED_AND_USED}
+```
+
+and
+
+```yaml
+# dep1/devspace.yaml
+vars:
+- name: DEFINED_AND_USED
+  value: my-dep-value
+- name: DEFINED_AND_NOT_USED
+  value: my-other-dep-value
+deployments:
+  # This will be my-other-dep-value
+- name: ${DEFINED_AND_NOT_USED}
+  helm:
+    componentChart: true
+    values:
+      containers:
+        # This will be my-base-value
+      - image: ${DEFINED_AND_USED}
+```

--- a/docs/versioned_docs/version-5.14/fragments/selector-image-selector.mdx
+++ b/docs/versioned_docs/version-5.14/fragments/selector-image-selector.mdx
@@ -1,8 +1,8 @@
-The `imageSelector` option expects an image (e.g. `my-registry.com/lib/my-image:tag`) to select a target pod and container with. The newest running pod that has a container that specifies this image will be selected by DevSpace.
+The `imageSelector` option expects a string that specifies an image (e.g. `my-registry.com/lib/my-image:tag`) to select a target pod and container with. The newest running pod that has a container which matches this image will be selected by DevSpace.
 
-Besides specifying a complete image, you can also reference images from the `images` section or even from `dependencies` within the `imageSelector` with:
-- If the image you specify exists in `images.*.image`, DevSpace will automatically append the latest built tag during runtime.
-- You can also let DevSpace resolve the actual image name and latest tag by using the helpers `image()` or `tag()`
+In addition, you can also reference images from the `images` section in the `imageSelector` with:
+- If the image in `imageSelector` matches a `images.*.image`, DevSpace will automatically append the latest built tag during runtime to the `imageSelector`.
+- You can also let DevSpace resolve the target image and tag by using the helpers `image()` or `tag()`
 
 For example:
 ```yaml

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -904,7 +904,7 @@ type DependencyConfig struct {
 	Profile            string          `yaml:"profile,omitempty" json:"profile,omitempty"`
 	ProfileParents     []string        `yaml:"profileParents,omitempty" json:"profileParents,omitempty"`
 	Vars               []DependencyVar `yaml:"vars,omitempty" json:"vars,omitempty"`
-	ForwardVars        *bool           `yaml:"forwardVars,omitempty" json:"forwardVars,omitempty"`
+	OverwriteVars      *bool           `yaml:"overwriteVars,omitempty" json:"overwriteVars,omitempty"`
 	SkipBuild          bool            `yaml:"skipBuild,omitempty" json:"skipBuild,omitempty"`
 	IgnoreDependencies bool            `yaml:"ignoreDependencies,omitempty" json:"ignoreDependencies,omitempty"`
 	Namespace          string          `yaml:"namespace,omitempty" json:"namespace,omitempty"`

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -904,6 +904,7 @@ type DependencyConfig struct {
 	Profile            string          `yaml:"profile,omitempty" json:"profile,omitempty"`
 	ProfileParents     []string        `yaml:"profileParents,omitempty" json:"profileParents,omitempty"`
 	Vars               []DependencyVar `yaml:"vars,omitempty" json:"vars,omitempty"`
+	ForwardVars        *bool           `yaml:"forwardVars,omitempty" json:"forwardVars,omitempty"`
 	SkipBuild          bool            `yaml:"skipBuild,omitempty" json:"skipBuild,omitempty"`
 	IgnoreDependencies bool            `yaml:"ignoreDependencies,omitempty" json:"ignoreDependencies,omitempty"`
 	Namespace          string          `yaml:"namespace,omitempty" json:"namespace,omitempty"`

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -224,7 +224,7 @@ func (r *resolver) resolveDependency(basePath string, dependency *latest.Depende
 	if cloned.Vars == nil {
 		cloned.Vars = []string{}
 	}
-	if dependency.ForwardVars == nil || *dependency.ForwardVars == true {
+	if dependency.OverwriteVars == nil || *dependency.OverwriteVars == true {
 		for k, v := range r.BaseVars {
 			cloned.Vars = append(cloned.Vars, strings.TrimSpace(k)+"="+strings.TrimSpace(fmt.Sprintf("%v", v)))
 		}

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -224,8 +224,10 @@ func (r *resolver) resolveDependency(basePath string, dependency *latest.Depende
 	if cloned.Vars == nil {
 		cloned.Vars = []string{}
 	}
-	for k, v := range r.BaseVars {
-		cloned.Vars = append(cloned.Vars, strings.TrimSpace(k)+"="+strings.TrimSpace(fmt.Sprintf("%v", v)))
+	if dependency.ForwardVars == nil || *dependency.ForwardVars == true {
+		for k, v := range r.BaseVars {
+			cloned.Vars = append(cloned.Vars, strings.TrimSpace(k)+"="+strings.TrimSpace(fmt.Sprintf("%v", v)))
+		}
 	}
 	for _, v := range dependency.Vars {
 		cloned.Vars = append(cloned.Vars, strings.TrimSpace(v.Name)+"="+strings.TrimSpace(v.Value))


### PR DESCRIPTION
### Changes
- New `dependencies[*].overwriteVars` option to disable variable overwriting in dependencies (#1466)
- DevSpace will now automatically reset the parent deployment, statefulset or replicaset during `devspace dev` if a replaced pod cannot be found, but the parent was scaled down already