### PR TITLE
refactor: avoid unnecessary traversing during initial sync

### DIFF
--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -573,6 +573,7 @@ type ServiceConfig struct {
 
 // ServicePortConfig holds the port configuration of a component service
 type ServicePortConfig struct {
+	Name          string `yaml:"name,omitempty" json:"name,omitempty"`
 	Port          *int   `yaml:"port,omitempty" json:"port,omitempty"`
 	ContainerPort *int   `yaml:"containerPort,omitempty" json:"containerPort,omitempty"`
 	Protocol      string `yaml:"protocol,omitempty" json:"protocol,omitempty"`

--- a/pkg/devspace/sync/initial.go
+++ b/pkg/devspace/sync/initial.go
@@ -242,6 +242,8 @@ func (i *initialSyncer) deltaPath(absPath string, remoteState map[string]*FileIn
 	// Check if stat is somehow not there
 	if stat == nil {
 		return nil, nil
+	} else if i.o.IgnoreMatcher != nil && i.o.IgnoreMatcher.RequireFullScan() == false && i.o.IgnoreMatcher.Matches(relativePath, stat.IsDir()) {
+		return nil, nil
 	}
 
 	if stat.IsDir() {


### PR DESCRIPTION
### Changes
- Added `deployments[*].helm.values.service.ports[*].name` to schema (#1472)
- DevSpace doesn't traverse excluded paths locally anymore during initial sync