### PR TITLE
fix: still watch if stat errors

### DIFF
--- a/helper/server/downstream.go
+++ b/helper/server/downstream.go
@@ -73,7 +73,7 @@ func StartDownstreamServer(reader io.Reader, writer io.Writer, options *Downstre
 
 					stat, err := os.Stat(s)
 					if err != nil {
-						return true
+						return false
 					}
 
 					return ignoreMatcher.Matches(s[len(options.RemotePath):], stat.IsDir())

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -211,7 +211,7 @@ func (s *Sync) startUpstream() {
 
 		stat, err := os.Stat(path)
 		if err != nil {
-			return true
+			return false
 		}
 
 		return s.ignoreMatcher.Matches(path[len(s.LocalPath):], stat.IsDir())


### PR DESCRIPTION
### Changes
- Fixes an issue where the sync watcher would exclude paths if the initial stat of them has failed