### PR TITLE
feat(config): add name to dev.sync & dev.ports

### DIFF
--- a/docs/pages/configuration/development/file-synchronization.mdx
+++ b/docs/pages/configuration/development/file-synchronization.mdx
@@ -43,6 +43,28 @@ Every sync configuration consists of two essential parts:
 - [Pod/Container Selection](#podcontainer-selection)
 - [Sync Path Mapping via `localSubPath` and `containerPath`](#sync-path-mapping)
 
+## Configuration
+### `name`
+The `name` option is optional and expects a string stating the name of this sync configuration. This can be used as a steady identifier when using profile patches.
+
+For example:
+```yaml {3}
+dev:
+  sync:
+  - name: devbackend
+    imageSelector: john/devbackend
+    localSubPath: ./
+    containerPath: /app
+    excludePaths:
+    - node_modules/
+    - logs/
+profiles:
+- name: production
+  patches:
+  - op: replace
+    path: dev.sync.name=devbackend.imageSelector
+    value: john/prodbackend
+```
 
 ## Pod/Container Selection
 The following config options are needed to determine the container which the file synchronization should be established to:

--- a/docs/pages/configuration/development/port-forwarding.mdx
+++ b/docs/pages/configuration/development/port-forwarding.mdx
@@ -41,6 +41,26 @@ Every port-forwarding configuration consists of two parts:
 - [Pod/Container Selection](#pod-selection)
 - [Port Mapping via `port` (and optionally via `remotePort` and `bindAddress`)](#port-mapping-forward)
 
+## Configuration
+### `name`
+The `name` option is optional and expects a string stating the name of this port-forwarding configuration. This can be used as a steady identifier when using profile patches.
+
+For example:
+```yaml {3}
+dev:
+  ports:
+  - name: devbackend
+    imageSelector: john/devbackend
+    forward:
+    - port: 8080
+      remotePort: 80
+profiles:
+- name: production
+  patches:
+  - op: replace
+    path: dev.ports.name=devbackend.imageSelector
+    value: john/prodbackend
+```
 
 ## Pod Selection
 The following config options are needed to determine the pod to which the traffic should be forwarded:

--- a/docs/pages/configuration/development/reverse-port-forwarding.mdx
+++ b/docs/pages/configuration/development/reverse-port-forwarding.mdx
@@ -48,6 +48,27 @@ Every reverse port-forwarding configuration consists of two parts:
 - [Pod/Container Selection](#pod-selection)
 - [Port Mapping via `port` (and optionally via `remotePort` and `bindAddress`)](#port-mapping-reverseforward)
 
+## Configuration
+### `name`
+The `name` option is optional and expects a string stating the name of this reverse port-forwarding configuration. This can be used as a steady identifier when using profile patches.
+
+For example:
+```yaml {3}
+dev:
+  ports:
+  - name: devbackend
+    imageSelector: john/devbackend
+    reverseForward:
+    - port: 8080
+      remotePort: 80
+profiles:
+- name: production
+  patches:
+  - op: replace
+    path: dev.ports.name=devbackend.imageSelector
+    value: john/prodbackend
+```
+
 
 ## Pod Selection
 The following config options are needed to determine the pod from which the traffic should be forwarded to localhost:

--- a/docs/pages/configuration/reference.mdx
+++ b/docs/pages/configuration/reference.mdx
@@ -230,7 +230,8 @@ kubectl:                            # struct   | Options for deploying with "kub
 ### `dev.ports`
 ```yaml
 ports:                              # struct[] | Array of port forwarding settings for selected pods
-- imageName: someImage              # string   | Name of an image defined in `images` or in a dependency to select pods with
+- name: somePort                    # string   | Optional string stating the name of this port-forwarding configuration
+  imageName: someImage              # string   | Name of an image defined in `images` or in a dependency to select pods with
   imageSelector: john/backend:0.1   # string   | Image of a container by which DevSpace should select the pod
   labelSelector: ...                # struct   | Key Value map of labels and values to select pods with
   namespace: ""                     # string   | Kubernetes namespace to select pods in
@@ -256,7 +257,8 @@ open:                               # struct[] | Array of auto-open settings
 ### `dev.sync`
 ```yaml
 sync:                               # struct[] | Array of file sync settings for selected pods
-- imageName: someImage              # string   | Name of an image defined in `images` or in a dependency to select pods with
+- name: someSync                    # string   | Optional string stating the name of this sync configuration
+  imageName: someImage              # string   | Name of an image defined in `images` or in a dependency to select pods with
   imageSelector: john/backend:0.1   # string   | Image of a container by which DevSpace should select the pod
   labelSelector: ...                # struct   | Key Value map of labels and values to select pods with
   containerName: ""                 # string   | Container name to use after selecting a pod

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -704,6 +704,7 @@ type ReplacePod struct {
 
 // PortForwardingConfig defines the ports for a port forwarding to a DevSpace
 type PortForwardingConfig struct {
+	Name          string            `yaml:"name,omitempty" json:"name,omitempty"`
 	ImageSelector string            `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	ImageName     string            `yaml:"imageName,omitempty" json:"imageName,omitempty"`
 	LabelSelector map[string]string `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`
@@ -731,6 +732,7 @@ type OpenConfig struct {
 
 // SyncConfig defines the paths for a SyncFolder
 type SyncConfig struct {
+	Name                 string               `yaml:"name,omitempty" json:"name,omitempty"`
 	ImageSelector        string               `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	ImageName            string               `yaml:"imageName,omitempty" json:"imageName,omitempty"`
 	LabelSelector        map[string]string    `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`


### PR DESCRIPTION
## Changes

- New option `name` for `dev.sync` and `dev.ports`. This can be used as a steady identifier when using profile patches. (#1577)