### PR TITLE
Multiple Improvements

### DIFF
--- a/docs/pages/configuration/development/log-streaming.mdx
+++ b/docs/pages/configuration/development/log-streaming.mdx
@@ -19,80 +19,18 @@ dev:
     showLast: 200
     # To display the sync log as well
     sync: true
-    images:
-    - backend
-    - frontend
-    # Other label selectors to forward logs from
-    selectors: ...
+    selectors:
+    - imageSelector: john/appbackend
+    - imageSelector: john/database
 ```
 
 DevSpace will continously check what pods match the given selectors and start or end log streaming accordingly.
 
 ## Configuration
 
-### `images`
-The `images` option expects an array of strings with image names. DevSpace uses this list to determine which containers to use for the multi-container log streaming.
-
-:::info
-By default, DevSpace streams the logs of **all** containers that are created based on images defined in the `images` section of the `devspace.yaml`.
-:::
-
-#### Example: Stream Only Containers Using Specified Images
-```yaml {2,4,35-38}
-images:
-  frontend:
-    image: john/appfrontend
-  backend:
-    image: john/appbackend
-  database:
-    image: john/database
-deployments:
-- name: app-frontend
-  helm:
-    componentChart: true
-    values:
-      containers:
-      - image: john/appfrontend
-- name: app-backend
-  helm:
-    componentChart: true
-    values:
-      containers:
-      - image: john/appbackend
-      - image: john/appbackend-sidecar
-- name: app-database
-  helm:
-    componentChart: true
-    values:
-      containers:
-      - image: john/database
-- name: app-cache
-  helm:
-    componentChart: true
-    values:
-      containers:
-      - image: redis:5.0.5
-dev:
-  logs:
-    images:
-    - backend
-    - frontend
-```
-**Explanation:**  
-- The above example defines 3 images and 5 deployments.
-- The `images` option defines that only containers using the `image` value of the images `backend` and `frontend` should be streamed.
-- The result would be that DevSpace streams the logs of:
-  - The container of deployment `app-frontend` because the image is `john/appfrontend` = `images.frontend.image`
-  - Only the first container of deployment `app-backend` because the image is `john/appbackend` = `images.backend.image`
-  
-:::note
-The **second** container of deployment `app-backend` would **not** be streamed in this example.
-:::
-
-
 ### `selectors`
 
-Besides `images`, DevSpaces allows log streaming from other pods and containers as well. You can configure them under the option `selectors`.
+DevSpaces allows log streaming from pods and containers based on label or image selectors. You can configure them under the option `selectors`.
 
 ```yaml
 dev:
@@ -105,6 +43,8 @@ dev:
       namespace: optional
     - labelSelector:
         other: selector   
+    - imageSelector: nginx
+      namespace: optional
 ```
 
 ### `sync`

--- a/docs/pages/configuration/hooks/basics.mdx
+++ b/docs/pages/configuration/hooks/basics.mdx
@@ -19,6 +19,13 @@ hooks:
   when:
     before:
       images: all
+# Execute the hook in a golang shell (cross operating system compatible)
+- command: |
+    echo Hello
+    echo World
+  when:
+    before:
+      images: all
 # Execute the hook directly on the system (echo binary must exist)
 - command: "echo"
   args: ["before image building"]
@@ -78,11 +85,12 @@ DevSpace allows you to execute commands directly in a container instead of the l
 ```yaml
 ...
 hooks:
-- command: "echo"
-  args: ["Hello from within the container!"]
+- command: |
+    echo Hello World!
+    echo From within the container!
   where: 
     container:
-      imageName: default
+      imageSelector: nginx
       # Or select via labelSelector etc.
       # labelSelector: ...
       # namespace: ...

--- a/docs/pages/configuration/reference.mdx
+++ b/docs/pages/configuration/reference.mdx
@@ -325,13 +325,14 @@ sync:                               # struct[] | Array of file sync settings for
 logs:                               # struct   | Options for multi-container log streaming in development mode
   disabled: false                   # bool     | Disable log streaming in development mode (Default: false)
   showLast: 200                     # int      | Number of last log lines to show before starting stream (Default: 50)
-  images: []                        # string[] | Array of image names referencing images defined in `images` for selecting containers for log streaming
   sync: true                        # bool     | If the sync log should be merged with container and pod logs
-  selectors:                        # struct[] | An array of additional label selectors to select pods to stream logs from
+  selectors:                        # struct[] | An array of label or image selectors to select pods to stream logs from
   - labelSelector:            
       other: label
     namespace: optional
-    containerName: optional 
+    containerName: optional
+  - imageSelector: nginx
+    namespace: optional
 ```
 [Learn more about configuring multi-container log streaming.](../configuration/development/log-streaming.mdx)
 

--- a/examples/minikube/Dockerfile
+++ b/examples/minikube/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.4-alpine
+FROM node:13.12-alpine
 
 RUN mkdir /app
 WORKDIR /app

--- a/pkg/devspace/build/builder/custom/custom.go
+++ b/pkg/devspace/build/builder/custom/custom.go
@@ -13,7 +13,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/util/hash"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 
-	dockerterm "github.com/docker/docker/pkg/term"
+	dockerterm "github.com/moby/term"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )

--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -412,14 +412,11 @@ func validateDev(config *latest.Config) error {
 			}
 		}
 	}
-	
+
 	if config.Dev.Logs != nil {
 		for index, selector := range config.Dev.Logs.Selectors {
 			if selector.ImageSelector != "" && len(selector.LabelSelector) > 0 {
 				return errors.Errorf("Error in config: dev.logs.selectors[%d].imageSelector and dev.logs.selectors[%d].labelSelector cannot be used together", index, index)
-			}
-			if selector.ImageSelector != "" && selector.Namespace != "" {
-				return errors.Errorf("Error in config: dev.logs.selectors[%d].imageSelector and dev.logs.selectors[%d].namespace cannot be used together", index, index)
 			}
 			if selector.ImageSelector != "" && selector.ContainerName != "" {
 				return errors.Errorf("Error in config: dev.logs.selectors[%d].imageSelector and dev.logs.selectors[%d].containerName cannot be used together", index, index)

--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -167,6 +167,21 @@ func validateCommands(config *latest.Config) error {
 
 func validateHooks(config *latest.Config) error {
 	for index, hookConfig := range config.Hooks {
+		if hookConfig.When == nil {
+			return errors.Errorf("hooks[%d].when is required", index)
+		}
+		if hookConfig.When.After == nil && hookConfig.When.Before == nil && hookConfig.When.OnError == nil {
+			return errors.Errorf("hooks[%d].when.after or hooks[%d].when.before or hooks[%d].when.onError is required", index, index, index)
+		}
+		if hookConfig.When != nil && hookConfig.When.OnError != nil && hookConfig.When.OnError.InitialSync != "" {
+			return errors.Errorf("hooks[%d].when.onError.initialSync is not yet supported", index)
+		}
+		if hookConfig.When != nil && hookConfig.When.After != nil && hookConfig.When.After.InitialSync == "all" {
+			return errors.Errorf("hooks[%d].when.after.initialSync all is not yet supported", index)
+		}
+		if hookConfig.When != nil && hookConfig.When.Before != nil && hookConfig.When.Before.InitialSync == "all" {
+			return errors.Errorf("hooks[%d].when.before.initialSync all is not yet supported", index)
+		}
 		if hookConfig.Command == "" && hookConfig.Upload == nil && hookConfig.Download == nil && hookConfig.Logs == nil && hookConfig.Wait == nil {
 			return errors.Errorf("hooks[%d].command, hooks[%d].logs, hooks[%d].wait, hooks[%d].download or hooks[%d].upload is required", index, index, index, index, index)
 		}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1048,6 +1048,7 @@ type HookWhenAtConfig struct {
 	Deployments      string `yaml:"deployments,omitempty" json:"deployments,omitempty"`
 	Dependencies     string `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 	PullSecrets      string `yaml:"pullSecrets,omitempty" json:"pullSecrets,omitempty"`
+	InitialSync      string `yaml:"initialSync,omitempty" json:"initialSync,omitempty"`
 }
 
 // CommandConfig defines the command specification

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -850,6 +850,7 @@ type LogsConfig struct {
 
 // LogsSelector holds configuration how to select a log target
 type LogsSelector struct {
+	ImageSelector string            `yaml:"imageSelector,omitempty" json:"imageSelector,omitempty"`
 	LabelSelector map[string]string `yaml:"labelSelector,omitempty" json:"labelSelector,omitempty"`
 	Namespace     string            `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 	ContainerName string            `yaml:"containerName,omitempty" json:"containerName,omitempty"`

--- a/pkg/devspace/hook/hook.go
+++ b/pkg/devspace/hook/hook.go
@@ -3,7 +3,6 @@ package hook
 import (
 	"bytes"
 	"fmt"
-	dockerterm "github.com/docker/docker/pkg/term"
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
@@ -12,6 +11,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/util/command"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/mgutz/ansi"
+	dockerterm "github.com/moby/term"
 	"github.com/pkg/errors"
 	"io"
 	"k8s.io/apimachinery/pkg/labels"
@@ -77,6 +77,8 @@ const (
 	StageDependencies Stage = "dependencies"
 	// StagePullSecrets is the pull secrets stage
 	StagePullSecrets Stage = "pullSecrets"
+	// StageInitialSync is the initial sync stage
+	StageInitialSync Stage = "initialSync"
 )
 
 // All is used to tell devspace to execute a hook before or after all images, deployments
@@ -137,6 +139,8 @@ func (e *executer) Execute(when When, stage Stage, which string, context Context
 						hooksToExecute = append(hooksToExecute, hook)
 					} else if stage == StagePullSecrets && hook.When.Before.PullSecrets != "" && strings.TrimSpace(hook.When.Before.PullSecrets) == strings.TrimSpace(which) {
 						hooksToExecute = append(hooksToExecute, hook)
+					} else if stage == StageInitialSync && hook.When.Before.InitialSync != "" && strings.TrimSpace(hook.When.Before.InitialSync) == strings.TrimSpace(which) {
+						hooksToExecute = append(hooksToExecute, hook)
 					}
 				} else if when == After && hook.When.After != nil {
 					if stage == StageDeployments && hook.When.After.Deployments != "" && strings.TrimSpace(hook.When.After.Deployments) == strings.TrimSpace(which) {
@@ -149,6 +153,8 @@ func (e *executer) Execute(when When, stage Stage, which string, context Context
 						hooksToExecute = append(hooksToExecute, hook)
 					} else if stage == StagePullSecrets && hook.When.After.PullSecrets != "" && strings.TrimSpace(hook.When.After.PullSecrets) == strings.TrimSpace(which) {
 						hooksToExecute = append(hooksToExecute, hook)
+					} else if stage == StageInitialSync && hook.When.After.InitialSync != "" && strings.TrimSpace(hook.When.After.InitialSync) == strings.TrimSpace(which) {
+						hooksToExecute = append(hooksToExecute, hook)
 					}
 				} else if when == OnError && hook.When.OnError != nil {
 					if stage == StageDeployments && hook.When.OnError.Deployments != "" && strings.TrimSpace(hook.When.OnError.Deployments) == strings.TrimSpace(which) {
@@ -160,6 +166,8 @@ func (e *executer) Execute(when When, stage Stage, which string, context Context
 					} else if stage == StageDependencies && hook.When.OnError.Dependencies != "" && strings.TrimSpace(hook.When.OnError.Dependencies) == strings.TrimSpace(which) {
 						hooksToExecute = append(hooksToExecute, hook)
 					} else if stage == StagePullSecrets && hook.When.OnError.PullSecrets != "" && strings.TrimSpace(hook.When.OnError.PullSecrets) == strings.TrimSpace(which) {
+						hooksToExecute = append(hooksToExecute, hook)
+					} else if stage == StageInitialSync && hook.When.OnError.InitialSync != "" && strings.TrimSpace(hook.When.OnError.InitialSync) == strings.TrimSpace(which) {
 						hooksToExecute = append(hooksToExecute, hook)
 					}
 				}

--- a/pkg/devspace/hook/hook.go
+++ b/pkg/devspace/hook/hook.go
@@ -253,11 +253,13 @@ func executeHook(ctx Context, hookConfig *latest.HookConfig, hookWriter io.Write
 
 func hookName(hook *latest.HookConfig) string {
 	if hook.Command != "" {
-		if hook.Args == nil {
-			return hook.Command
+		commandString := strings.TrimSpace(hook.Command + " " + strings.Join(hook.Args, " "))
+		splitted := strings.Split(commandString, "\n")
+		if len(splitted) > 1 {
+			return splitted[0] + "..."
 		}
 
-		return fmt.Sprintf("%s %s", hook.Command, strings.Join(hook.Args, " "))
+		return commandString
 	}
 	if hook.Upload != nil && hook.Where.Container != nil {
 		localPath := "."

--- a/pkg/devspace/hook/remote_command.go
+++ b/pkg/devspace/hook/remote_command.go
@@ -22,7 +22,12 @@ type remoteCommandHook struct {
 
 func (r *remoteCommandHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *kubectl.SelectedPodContainer, log logpkg.Logger) error {
 	cmd := []string{hook.Command}
-	cmd = append(cmd, hook.Args...)
+	if hook.Args == nil {
+		cmd = []string{"sh", "-c", hook.Command}
+	} else {
+		cmd = append(cmd, hook.Args...)
+	}
+
 	err := ctx.Client.ExecStream(&kubectl.ExecStreamOptions{
 		Pod:       podContainer.Pod,
 		Container: podContainer.Container.Name,

--- a/pkg/devspace/services/log_manager.go
+++ b/pkg/devspace/services/log_manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
+	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
 	"github.com/loft-sh/devspace/pkg/util/log"
@@ -47,17 +48,39 @@ func NewLogManager(client kubectl.Client, config config.Config, dependencies []t
 	}
 
 	// get config
-	c := config.Config()
+	var (
+		c              = config.Config()
+		tail           *int64
+		imageSelectors = []imageselector.ImageSelector{}
+		labelSelectors = []latest.LogsSelector{}
+	)
 
-	// Build an image selector
-	imageSelector := []imageselector.ImageSelector{}
-	if c.Dev.Logs != nil && c.Dev.Logs.Images != nil {
+	if c.Dev.Logs != nil {
+		if c.Dev.Logs.ShowLast != nil {
+			tail = ptr.Int64(int64(*c.Dev.Logs.ShowLast))
+		}
+
+		// resolve image names
 		for _, configImageName := range c.Dev.Logs.Images {
 			selector, err := imageselector.Resolve(configImageName, config, dependencies)
 			if err != nil {
 				return nil, err
 			} else if selector != nil {
-				imageSelector = append(imageSelector, *selector)
+				imageSelectors = append(imageSelectors, *selector)
+			}
+		}
+
+		// resolve selectors
+		for _, selector := range c.Dev.Logs.Selectors {
+			if selector.ImageSelector != "" {
+				imageSelector, err := util.ResolveImageAsImageSelector(selector.ImageSelector, config, dependencies)
+				if err != nil {
+					return nil, err
+				}
+
+				imageSelectors = append(imageSelectors, *imageSelector)
+			} else {
+				labelSelectors = append(labelSelectors, selector)
 			}
 		}
 	} else {
@@ -66,29 +89,18 @@ func NewLogManager(client kubectl.Client, config config.Config, dependencies []t
 			if err != nil {
 				return nil, err
 			} else if selector != nil {
-				imageSelector = append(imageSelector, *selector)
+				imageSelectors = append(imageSelectors, *selector)
 			}
 		}
 	}
 
-	// Show last log lines
-	var tail *int64
-	if c.Dev.Logs != nil && c.Dev.Logs.ShowLast != nil {
-		tail = ptr.Int64(int64(*c.Dev.Logs.ShowLast))
-	}
-
-	var selectors []latest.LogsSelector
-	if c.Dev.Logs != nil {
-		selectors = c.Dev.Logs.Selectors
-	}
 	if tail == nil {
 		tail = ptr.Int64(50)
 	}
-
 	return &logManager{
 		client:             client,
-		imageNameSelectors: imageSelector,
-		labelSelectors:     selectors,
+		imageNameSelectors: imageSelectors,
+		labelSelectors:     labelSelectors,
 		interrupt:          interrupt,
 		output:             out,
 		tail:               *tail,

--- a/pkg/devspace/sync/initial.go
+++ b/pkg/devspace/sync/initial.go
@@ -31,7 +31,7 @@ type initialSyncOptions struct {
 	DownstreamDisabled bool
 	FileIndex          *fileIndex
 
-	ApplyRemote func(changes []*FileInformation, remove bool)
+	ApplyRemote func(changes []*FileInformation)
 	ApplyLocal  func(changes []*remote.Change, force bool) error
 	AddSymlink  func(relativePath, absPath string) (os.FileInfo, error)
 
@@ -75,7 +75,7 @@ func (i *initialSyncer) Run(remoteState map[string]*FileInformation) error {
 					})
 				}
 
-				i.o.ApplyRemote(deleteRemote, true)
+				i.o.ApplyRemote(deleteRemote)
 			}
 
 			// Upload remote if not mirror remote
@@ -89,13 +89,12 @@ func (i *initialSyncer) Run(remoteState map[string]*FileInformation) error {
 						}
 					}
 					if len(changes) > 0 {
-						i.o.ApplyRemote(changes, false)
+						i.o.ApplyRemote(changes)
 					}
 				} else {
-					i.o.ApplyRemote(upload, false)
+					i.o.ApplyRemote(upload)
 				}
 			}
-
 		}
 
 		i.o.UpstreamDone()

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -18,6 +18,8 @@ import (
 var syncRetries = 5
 var initialUpstreamBatchSize = 1000
 
+const waitForMoreChangesTimeout = time.Minute
+
 // Options holds the sync options
 type Options struct {
 	Polling bool

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -302,7 +302,7 @@ func (s *Sync) initialSync(onInitUploadDone chan struct{}, onInitDownloadDone ch
 	return initialSync.Run(downloadChanges)
 }
 
-func (s *Sync) sendChangesToUpstream(changes []*FileInformation, remove bool) {
+func (s *Sync) sendChangesToUpstream(changes []*FileInformation) {
 	for j := 0; j < len(changes); j += initialUpstreamBatchSize {
 		// Wait till upstream channel is empty
 		for len(s.upstream.events) > 0 {
@@ -314,11 +314,7 @@ func (s *Sync) sendChangesToUpstream(changes []*FileInformation, remove bool) {
 		s.fileIndex.fileMapMutex.Lock()
 
 		for i := j; i < (j+initialUpstreamBatchSize) && i < len(changes); i++ {
-			if remove {
-				sendBatch = append(sendBatch, changes[i])
-			} else if s.fileIndex.fileMap[changes[i].Name] == nil || (s.fileIndex.fileMap[changes[i].Name] != nil && changes[i].Mtime > s.fileIndex.fileMap[changes[i].Name].Mtime) {
-				sendBatch = append(sendBatch, changes[i])
-			}
+			sendBatch = append(sendBatch, changes[i])
 		}
 
 		s.fileIndex.fileMapMutex.Unlock()

--- a/pkg/util/log/prefix_logger.go
+++ b/pkg/util/log/prefix_logger.go
@@ -16,7 +16,6 @@ var Colors = []string{
 	"yellow",
 	"magenta",
 	"cyan",
-	"red",
 	"white+b",
 }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,7 +30,7 @@
     "js-sha256": "^0.9.0",
     "js-yaml": "^3.13.1",
     "moment": "^2.24.0",
-    "node-sass": "^5.0.0",
+    "node-sass": "^4.0.0",
     "npm-run-all": "^4.1.5",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "4.1.0",

--- a/ui/src/lib/fetch.ts
+++ b/ui/src/lib/fetch.ts
@@ -1,5 +1,5 @@
 import {ApiHostname} from "./rest";
 
 export default function authFetch(url: string): Promise<Response> {
-    return fetch(`http://${ApiHostname()}${url}`)
+    return fetch(`${window.location.protocol}//${ApiHostname()}${url}`)
 }


### PR DESCRIPTION
### Changes
- New `dev.logs.selectors[*].imageSelector` option to select images that should be logged by image name
- Fixed an issue where DevSpace would get stuck uploading or downloading files that would change frequently (#1576)
- Fixed an issue where `http` was hardcoded as target domain in DevSpace UI (#1574)
- Removed red from log streaming color palette to avoid confusion with errors (#1583)
- DevSpace will now run remote hook commands in a remote shell if no args are specified. For example this is now possible:
```yaml
hooks:
- command: |
    echo 123
    echo 456
    echo 789
  where:
    container:
      imageSelector: my-image
  when:
    after:
      deployments: all
```
- New `hooks[*].when.before.initialSync` and `hooks[*].when.after.initialSync` that executes a hook after or before a certain sync configuration's initial sync has started
- Fixed an issue where the sync would skip to upload files initially that were newer on the remote side