### PR TITLE
docs: document configName for dependency sources

### DIFF
--- a/docs/pages/configuration/dependencies/git-repository.mdx
+++ b/docs/pages/configuration/dependencies/git-repository.mdx
@@ -98,6 +98,25 @@ The `source.subPath` option expects a string stating a folder within the git rep
 subPath: /
 ```
 
+### `source.configName`
+The `source.configName` option is optional and specifies the dependency's DevSpace configuration file name within the git repository's `source.subPath` folder.
+
+#### Default Value For `source.configName`
+```yaml
+configName: devspace.yaml
+```
+
+#### Example: Use dev.yaml for Dependency's DevSpace Configuration
+```yaml
+# This will use the file dev.yaml for the dependency's DevSpace configuration
+# at the root folder of the repository's "stable" branch
+dependencies:
+- source:
+    git: https://github.com/my-api-server
+    branch: stable
+    configName: dev.yaml
+```
+
 
 ## Git Options
 
@@ -120,7 +139,6 @@ The `source.cloneArgs` option expects an array of additional arguments that DevS
 ```yaml
 cloneArgs: []
 ```
-
 
 ## General Options
 

--- a/docs/pages/configuration/dependencies/local-folder.mdx
+++ b/docs/pages/configuration/dependencies/local-folder.mdx
@@ -49,6 +49,23 @@ dependencies:
   - Load the `devspace.yaml` files of both dependencies and resolve their dependencies respectively.
   - Deploy both projects according to their `devspace.yaml` files.
 
+### `source.configName`
+The `source.configName` option is optional and specifies the dependency's DevSpace configuration file name. If not provided, `devspace.yaml` at the dependency `source.path` will be used.
+
+#### Default Value For `source.configName`
+```yaml
+configName: devspace.yaml
+```
+
+#### Example: Use dev.yaml for Dependency's DevSpace Configuration
+```yaml
+# This will use the file component-1/dev.yaml
+# for the dependency's DevSpace configuration
+dependencies:
+- source:
+    path: component-1
+    configName: dev.yaml
+```
 
 ## General Options
 


### PR DESCRIPTION
### Changes
- Document `dependencies.[*].source.configName` option to override DevSpace configuration file name