### PR TITLE
Auto-Activate Profiles based on Environment Variables

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -15,13 +15,14 @@ type GlobalFlags struct {
 	NoWarn bool
 	Debug  bool
 
-	Namespace      string
-	KubeContext    string
-	Profiles       []string
-	ProfileRefresh bool
-	ProfileParents []string
-	ConfigPath     string
-	Vars           []string
+	Namespace                string
+	KubeContext              string
+	Profiles                 []string
+	ProfileRefresh           bool
+	ProfileParents           []string
+	DisableProfileActivation bool
+	ConfigPath               string
+	Vars                     []string
 
 	RestoreVars    bool
 	SaveVars       bool
@@ -66,15 +67,16 @@ func (gf *GlobalFlags) ToConfigOptions(log log.Logger) *loader.ConfigOptions {
 		gf.ProfileParents = append(gf.ProfileParents, gf.Profiles[:len(gf.Profiles)-1]...)
 	}
 	return &loader.ConfigOptions{
-		Profile:        profile,
-		ProfileRefresh: gf.ProfileRefresh,
-		ProfileParents: gf.ProfileParents,
-		KubeContext:    gf.KubeContext,
-		Namespace:      gf.Namespace,
-		Vars:           gf.Vars,
-		RestoreVars:    gf.RestoreVars,
-		SaveVars:       gf.SaveVars,
-		VarsSecretName: gf.VarsSecretName,
+		Profile:                  profile,
+		ProfileRefresh:           gf.ProfileRefresh,
+		ProfileParents:           gf.ProfileParents,
+		DisableProfileActivation: gf.DisableProfileActivation,
+		KubeContext:              gf.KubeContext,
+		Namespace:                gf.Namespace,
+		Vars:                     gf.Vars,
+		RestoreVars:              gf.RestoreVars,
+		SaveVars:                 gf.SaveVars,
+		VarsSecretName:           gf.VarsSecretName,
 	}
 }
 
@@ -93,6 +95,7 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 	flags.StringSliceVarP(&globalFlags.Profiles, "profile", "p", []string{}, "The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified")
 	flags.StringSliceVar(&globalFlags.ProfileParents, "profile-parent", []string{}, "One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)")
 	flags.BoolVar(&globalFlags.ProfileRefresh, "profile-refresh", false, "If true will pull and re-download profile parent sources")
+	flags.BoolVar(&globalFlags.DisableProfileActivation, "disable-profile-activation", false, "If true will ignore all profile activations")
 	flags.StringVarP(&globalFlags.Namespace, "namespace", "n", "", "The kubernetes namespace to use")
 	flags.StringVar(&globalFlags.KubeContext, "kube-context", "", "The kubernetes context to use")
 	flags.BoolVarP(&globalFlags.SwitchContext, "switch-context", "s", false, "Switches and uses the last kube context and namespace that was used to deploy the DevSpace project")

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -58,18 +58,12 @@ func (gf *GlobalFlags) ToConfigOptions(log log.Logger) *loader.ConfigOptions {
 		log.Infof("--profile-parent is deprecated, please use --profile instead")
 	}
 
-	if gf.ProfileParents == nil {
-		gf.ProfileParents = []string{}
-	}
-	profile := ""
-	if len(gf.Profiles) > 0 {
-		profile = gf.Profiles[len(gf.Profiles)-1]
-		gf.ProfileParents = append(gf.ProfileParents, gf.Profiles[:len(gf.Profiles)-1]...)
-	}
+	profiles := []string{}
+	profiles = append(profiles, gf.ProfileParents...)
+	profiles = append(profiles, gf.Profiles...)
 	return &loader.ConfigOptions{
-		Profile:                  profile,
+		Profiles:                 profiles,
 		ProfileRefresh:           gf.ProfileRefresh,
-		ProfileParents:           gf.ProfileParents,
 		DisableProfileActivation: gf.DisableProfileActivation,
 		KubeContext:              gf.KubeContext,
 		Namespace:                gf.Namespace,

--- a/cmd/flags/flags_test.go
+++ b/cmd/flags/flags_test.go
@@ -65,8 +65,8 @@ func TestToConfigOptions(t *testing.T) {
 		Vars:        []string{"var1", "var2"},
 	}).ToConfigOptions(log.Discard)
 
-	assert.Equal(t, configOptions.Profile, "myProfile", "ConfigOptions has wrong profile")
-	assert.Equal(t, len(configOptions.ProfileParents), 1)
+	assert.Equal(t, configOptions.Profiles[0], "myProfile2", "ConfigOptions has wrong profiles")
+	assert.Equal(t, configOptions.Profiles[1], "myProfile", "ConfigOptions has wrong profiles")
 	assert.Equal(t, configOptions.KubeContext, "myKubeContext", "ConfigOptions has wrong kube context")
 	assert.Equal(t, len(configOptions.Vars), 2, "ConfigOptions has wrong vars")
 	assert.Equal(t, configOptions.Vars[0], "var1", "ConfigOptions has wrong vars")

--- a/docs/pages/commands/devspace.md
+++ b/docs/pages/commands/devspace.md
@@ -16,22 +16,23 @@ DevSpace accelerates developing, deploying and debugging applications with Docke
 ### Options
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-  -h, --help                     help for devspace
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      -h, --help                     help for devspace
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
 
 ```

--- a/docs/pages/commands/devspace_add.md
+++ b/docs/pages/commands/devspace_add.md
@@ -27,20 +27,20 @@ Adds config sections to devspace.yaml
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_add_plugin.md
+++ b/docs/pages/commands/devspace_add_plugin.md
@@ -35,20 +35,20 @@ devspace add plugin https://github.com/my-plugin/plugin
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_analyze.md
+++ b/docs/pages/commands/devspace_analyze.md
@@ -41,20 +41,20 @@ devspace analyze --namespace=mynamespace
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_attach.md
+++ b/docs/pages/commands/devspace_attach.md
@@ -42,20 +42,20 @@ devspace attach -n my-namespace
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_build.md
+++ b/docs/pages/commands/devspace_build.md
@@ -41,20 +41,20 @@ Builds all defined images and pushes them
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_cleanup.md
+++ b/docs/pages/commands/devspace_cleanup.md
@@ -26,20 +26,20 @@ Cleans up resources
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_cleanup_images.md
+++ b/docs/pages/commands/devspace_cleanup_images.md
@@ -32,20 +32,20 @@ Deletes all locally created docker images from docker
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_deploy.md
+++ b/docs/pages/commands/devspace_deploy.md
@@ -50,20 +50,20 @@ devspace deploy --kube-context=deploy-context
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_dev.md
+++ b/docs/pages/commands/devspace_dev.md
@@ -64,20 +64,20 @@ Open terminal instead of logs:
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_enter.md
+++ b/docs/pages/commands/devspace_enter.md
@@ -47,20 +47,20 @@ devspace enter bash -l release=test
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_init.md
+++ b/docs/pages/commands/devspace_init.md
@@ -37,20 +37,20 @@ folder. Creates a devspace.yaml with all configuration.
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list.md
+++ b/docs/pages/commands/devspace_list.md
@@ -26,20 +26,20 @@ Lists configuration
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_commands.md
+++ b/docs/pages/commands/devspace_list_commands.md
@@ -33,20 +33,20 @@ devspace.yaml
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_contexts.md
+++ b/docs/pages/commands/devspace_list_contexts.md
@@ -35,20 +35,20 @@ devspace list contexts
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_deployments.md
+++ b/docs/pages/commands/devspace_list_deployments.md
@@ -32,20 +32,20 @@ Shows the status of all deployments
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_namespaces.md
+++ b/docs/pages/commands/devspace_list_namespaces.md
@@ -32,20 +32,20 @@ Lists all namespaces in the selected kube context
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_plugins.md
+++ b/docs/pages/commands/devspace_list_plugins.md
@@ -34,20 +34,20 @@ devspace list plugins
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_ports.md
+++ b/docs/pages/commands/devspace_list_ports.md
@@ -32,20 +32,20 @@ Lists the port forwarding configurations
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_profiles.md
+++ b/docs/pages/commands/devspace_list_profiles.md
@@ -32,20 +32,20 @@ Lists all DevSpace configuartions for this project
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_sync.md
+++ b/docs/pages/commands/devspace_list_sync.md
@@ -32,20 +32,20 @@ Lists the sync configuration
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_list_vars.md
+++ b/docs/pages/commands/devspace_list_vars.md
@@ -34,20 +34,20 @@ values
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_logs.md
+++ b/docs/pages/commands/devspace_logs.md
@@ -45,20 +45,20 @@ devspace logs --namespace=mynamespace
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_open.md
+++ b/docs/pages/commands/devspace_open.md
@@ -37,20 +37,20 @@ devspace open
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_print.md
+++ b/docs/pages/commands/devspace_print.md
@@ -34,20 +34,20 @@ profile after all patching and variable substitution
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_purge.md
+++ b/docs/pages/commands/devspace_purge.md
@@ -41,20 +41,20 @@ devspace purge -d my-deployment
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_remove.md
+++ b/docs/pages/commands/devspace_remove.md
@@ -26,20 +26,20 @@ Changes devspace configuration
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_remove_context.md
+++ b/docs/pages/commands/devspace_remove_context.md
@@ -35,20 +35,20 @@ devspace remove context myspace
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_remove_plugin.md
+++ b/docs/pages/commands/devspace_remove_plugin.md
@@ -34,20 +34,20 @@ devspace remove plugin my-plugin
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_render.md
+++ b/docs/pages/commands/devspace_render.md
@@ -45,20 +45,20 @@ deployment.
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_reset.md
+++ b/docs/pages/commands/devspace_reset.md
@@ -26,20 +26,20 @@ Resets an cluster token
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_reset_dependencies.md
+++ b/docs/pages/commands/devspace_reset_dependencies.md
@@ -35,20 +35,20 @@ devspace reset dependencies
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_reset_pods.md
+++ b/docs/pages/commands/devspace_reset_pods.md
@@ -35,20 +35,20 @@ devspace reset pods
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_reset_vars.md
+++ b/docs/pages/commands/devspace_reset_vars.md
@@ -35,20 +35,20 @@ devspace reset vars
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_restart.md
+++ b/docs/pages/commands/devspace_restart.md
@@ -40,20 +40,20 @@ devspace restart -n my-namespace
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_restore.md
+++ b/docs/pages/commands/devspace_restore.md
@@ -26,20 +26,20 @@ Restore configuration
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_restore_vars.md
+++ b/docs/pages/commands/devspace_restore_vars.md
@@ -38,20 +38,20 @@ devspace restore vars --vars-secret my-secret
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_run.md
+++ b/docs/pages/commands/devspace_run.md
@@ -38,20 +38,20 @@ devspace --dependency my-dependency run any-command --any-command-flag
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_save.md
+++ b/docs/pages/commands/devspace_save.md
@@ -26,20 +26,20 @@ Save configuration
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_save_vars.md
+++ b/docs/pages/commands/devspace_save_vars.md
@@ -39,20 +39,20 @@ devspace save vars --vars-secret my-secret
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_set.md
+++ b/docs/pages/commands/devspace_set.md
@@ -26,20 +26,20 @@ Make global configuration changes
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_set_var.md
+++ b/docs/pages/commands/devspace_set_var.md
@@ -37,20 +37,20 @@ devspace set var key=value key2=value2
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_sync.md
+++ b/docs/pages/commands/devspace_sync.md
@@ -52,20 +52,20 @@ devspace sync --container-path=/my-path
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_ui.md
+++ b/docs/pages/commands/devspace_ui.md
@@ -36,20 +36,20 @@ Opens the localhost UI in the browser
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_update.md
+++ b/docs/pages/commands/devspace_update.md
@@ -26,20 +26,20 @@ Updates the current config
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_update_dependencies.md
+++ b/docs/pages/commands/devspace_update_dependencies.md
@@ -33,20 +33,20 @@ in the devspace.yaml
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_update_plugin.md
+++ b/docs/pages/commands/devspace_update_plugin.md
@@ -35,20 +35,20 @@ devspace update plugin my-plugin
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_upgrade.md
+++ b/docs/pages/commands/devspace_upgrade.md
@@ -33,20 +33,20 @@ Upgrades the DevSpace CLI to the newest version
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_use.md
+++ b/docs/pages/commands/devspace_use.md
@@ -26,20 +26,20 @@ Use specific config
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_use_context.md
+++ b/docs/pages/commands/devspace_use_context.md
@@ -35,20 +35,20 @@ devspace use context my-context
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_use_namespace.md
+++ b/docs/pages/commands/devspace_use_namespace.md
@@ -36,20 +36,20 @@ devspace use namespace my-namespace
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/commands/devspace_use_profile.md
+++ b/docs/pages/commands/devspace_use_profile.md
@@ -38,20 +38,20 @@ devspace use profile --reset
 ## Global & Inherited Flags
 
 ```
-      --config string            The devspace config file to use
-      --debug                    Prints the stack trace if an error occurs
-      --inactivity-timeout int   Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
-      --kube-context string      The kubernetes context to use
-  -n, --namespace string         The kubernetes namespace to use
-      --no-warn                  If true does not show any warning when deploying into a different namespace or kube-context than before
-  -p, --profile string           The devspace profile to use (if there is any)
-      --profile-parent strings   One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
-      --profile-refresh          If true will pull and re-download profile parent sources
-      --restore-vars             If true will restore the variables from kubernetes before loading the config
-      --save-vars                If true will save the variables to kubernetes after loading the config
-      --silent                   Run in silent mode and prevents any devspace log output except panics & fatals
-  -s, --switch-context           Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
-      --var strings              Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
-      --vars-secret string       The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
+      --config string                The devspace config file to use
+      --debug                        Prints the stack trace if an error occurs
+      --disable-profile-activation   If true will ignore all profile activations
+      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
+      --kube-context string          The kubernetes context to use
+  -n, --namespace string             The kubernetes namespace to use
+      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
+  -p, --profile string               The devspace profile to use (if there is any)
+      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
+      --profile-refresh              If true will pull and re-download profile parent sources
+      --restore-vars                 If true will restore the variables from kubernetes before loading the config
+      --save-vars                    If true will save the variables to kubernetes after loading the config
+      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
+  -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
+      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
+      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")
 ```
-

--- a/docs/pages/configuration/profiles/activation.mdx
+++ b/docs/pages/configuration/profiles/activation.mdx
@@ -1,0 +1,94 @@
+---
+title: "Profiles: Activation"
+sidebar_label: activation
+---
+
+The `activation` option is optional and allows you to activate a profile using regular expression matching of environment variables. An activation is configured with the profile it activates in `devspace.yaml`.
+
+#### Example: Defining a Profile Activation
+```yaml {3-5}
+profiles:
+- name: production
+  activation:
+  - env:
+      ENV: "production"
+  patches:
+  - op: replace
+    path: images.backend.image
+    value: john/prodbackend
+```
+The `production` profile would be activated when the environment variable `ENV` has value `production`:
+
+#### Example: Regular Expression Activation
+```yaml {3-5}
+profiles:
+- name: production
+  activation:
+  - env:
+      ENV: "prod-\d+"
+  patches:
+  - op: replace
+    path: images.backend.image
+    value: john/prodbackend
+```
+The profile `production` would be activated when the environment variable `ENV` matches the regular expression `prod-\d+`. This can be useful for matching environment variables that have dynamic values.
+
+#### Example: Matching All Environment Variables
+When multiple `env` name/expression pairs are specified in the same activation, all environment variables values must match the expression to activate the profile. For example, the `production` profile is activated when both environment variables match their expressions:
+```yaml {3-6}
+profiles:
+- name: production
+  activation:
+  - env:
+      CI: "true"
+      ENV: "development"
+  patches:
+  - op: replace
+    path: images.backend.image
+    value: john/devbackend
+```
+
+#### Example: Matching Any Environment Variables
+When environment variables are used in multiple activations, the profile is activated when any environment variable matches. In this example, the `production` profile is activated when either environment variables match their expressions:
+```yaml {3-7}
+profiles:
+- name: production
+  activation:
+  - env:
+      CI: "true"
+  - env:
+      ENV: "development"
+  patches:
+  - op: replace
+    path: images.backend.image
+    value: john/devbackend
+```
+
+### Dependency Activations
+When `dependencies` are referenced from a `devspace.yaml`, the dependency's profile activations will also be evaluated. In this example, any profile activations in `./component-1/devspace.yaml` or `./component-2/devspace.yaml` would be evaluated.
+
+```yaml
+dependencies:
+- name: component-1
+  source:
+    path: ./component-1
+- name: component-2
+  source:
+    path: ./component-2
+```
+
+#### Example: Disable Activations by Dependency
+The `disableProfileActivation` option can be used to disable profile activations for specific dependencies. In the following example, the activations for `./component-1/devspace.yaml` would be ignored, while the activations in `./component-2/devspace.yaml` would be evaluated:
+```yaml {5}
+dependencies:
+- name: component-1
+  source:
+    path: ./component-1
+  disableProfileActivation: true
+- name: component-2
+  source:
+    path: ./component-2
+```
+
+### Disable Activations Globally
+The `--disable-profile-activation` flag can be used to disable all profile activations, including those specifed within each dependency's `devspace.yaml`.

--- a/docs/pages/configuration/profiles/basics.mdx
+++ b/docs/pages/configuration/profiles/basics.mdx
@@ -59,7 +59,6 @@ profiles:
       image: john/cache
 ```
 
-
 ## Useful Commands
 
 ### `devspace print -p [profile]`

--- a/docs/pages/fragments/config-dependencies.mdx
+++ b/docs/pages/fragments/config-dependencies.mdx
@@ -9,7 +9,7 @@ dependencies:                       # struct[]  | Array of dependencies (other p
     disableShallow: false           # bool      | Allows to disable shallow git clones using "--depth 1"
     cloneArgs: []                   # string[]  | Array of args for the "git clone" command for retrieving git based dependencies
     path: ../../my-projects/repo    # string    | Path to a project on your local computer (not recommended, instead of using git-related options)
-  profile: default                  # string    | Name of the profile used to deploy this dependency (when multiple profiles are defined in the devspace.yaml of the dependency)
+  profiles: []                      # string[]  | Profiles used to deploy this dependency (when multiple profiles are defined in the devspace.yaml of the dependency)
   skipBuild: false                  # bool      | Do not build images of this dependency (= only start deployments)
   ignoreDependencies: false         # bool      | Do not build and deploy dependencies of this dependency
   namespace: ""                     # string    | Kubernetes namespace to deploy dependency to (Default: default namespace of current kube-context)
@@ -20,4 +20,5 @@ dependencies:                       # struct[]  | Array of dependencies (other p
   vars:                             # struct[]  | Variables in the dependency config that should be overriden with the specified values 
   - name: NAME
     value: value
+  disableProfileActivation: true    # bool      | If true will ignore profile activations for this dependency
 ```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -125,6 +125,7 @@ module.exports = {
             'configuration/profiles/strategic-merge',
             'configuration/profiles/patches',
             'configuration/profiles/parents',
+            'configuration/profiles/activation',
           ],
         },
         'configuration/pullSecrets/basics',

--- a/e2e/new/framework/helper.go
+++ b/e2e/new/framework/helper.go
@@ -44,3 +44,8 @@ func ExpectHaveKey(actual interface{}, key interface{}, explain ...interface{}) 
 func ExpectEmpty(actual interface{}, explain ...interface{}) {
 	gomega.ExpectWithOffset(1, actual).To(gomega.BeEmpty(), explain...)
 }
+
+// Expect returns a gomega assertion with offset
+func Expect(actual interface{}) gomega.Assertion {
+	return gomega.ExpectWithOffset(1, actual)
+}

--- a/e2e/new/tests/config/config.go
+++ b/e2e/new/tests/config/config.go
@@ -207,7 +207,7 @@ var _ = DevSpaceDescribe("config", func() {
 		framework.ExpectEqual(len(config.Config().Deployments), 1)
 
 		// reload it and set it through config options
-		config, _, err = framework.LoadConfigWithOptions(f, "devspace.yaml", &loader.ConfigOptions{Profile: "add-deployment"})
+		config, _, err = framework.LoadConfigWithOptions(f, "devspace.yaml", &loader.ConfigOptions{Profiles: []string{"add-deployment"}})
 		framework.ExpectNoError(err)
 
 		// check profile was loaded

--- a/e2e/new/tests/config/testdata/multiple-profiles/profiles.yaml
+++ b/e2e/new/tests/config/testdata/multiple-profiles/profiles.yaml
@@ -1,0 +1,44 @@
+version: v1beta10
+deployments:
+- name: test
+  kubectl:
+    manifests:
+      - test.yaml
+profiles:
+  - name: one
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test1
+          kubectl:
+            manifests:
+              - test1.yaml
+  - name: two
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test2
+          kubectl:
+            manifests:
+              - test2.yaml
+  - name: three
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test3
+          kubectl:
+            manifests:
+              - test3.yaml
+  - name: four
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test4
+          kubectl:
+            manifests:
+              - test4.yaml
+  

--- a/e2e/new/tests/config/testdata/profile-activation/and.yaml
+++ b/e2e/new/tests/config/testdata/profile-activation/and.yaml
@@ -1,0 +1,19 @@
+version: v1beta10
+profiles:
+  - name: one
+    activation:
+      - env:
+          FOO: "true"
+          BAR: "true"
+    patches:
+      - op: replace
+        path: deployments
+        value:
+        - name: test
+          kubectl:
+            manifests:
+              - test.yaml
+        - name: test2
+          kubectl:
+            manifests:
+              - test2.yaml

--- a/e2e/new/tests/config/testdata/profile-activation/default.yaml
+++ b/e2e/new/tests/config/testdata/profile-activation/default.yaml
@@ -1,0 +1,18 @@
+version: v1beta10
+profiles:
+  - name: one
+    activation:
+      - env:
+          FOO: "true"
+    patches:
+      - op: replace
+        path: deployments
+        value:
+        - name: test
+          kubectl:
+            manifests:
+              - test.yaml
+        - name: test2
+          kubectl:
+            manifests:
+              - test2.yaml

--- a/e2e/new/tests/config/testdata/profile-activation/multiple.yaml
+++ b/e2e/new/tests/config/testdata/profile-activation/multiple.yaml
@@ -1,0 +1,44 @@
+version: v1beta10
+deployments: []
+profiles:
+  - name: one
+    activation:
+      - env:
+          FOO: "true"
+    patches:
+      - op: replace
+        path: deployments
+        value:
+        - name: test
+          kubectl:
+            manifests:
+              - test.yaml
+        - name: test2
+          kubectl:
+            manifests:
+              - test2.yaml
+  - name: two
+    activation:
+      - env:
+          FOO: "true"
+    patches:
+      - op: remove
+        path: deployments[1]
+  - name: three
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test3
+          kubectl:
+            manifests:
+              - test3.yaml
+  - name: four
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test4
+          kubectl:
+            manifests:
+              - test4.yaml

--- a/e2e/new/tests/config/testdata/profile-activation/or.yaml
+++ b/e2e/new/tests/config/testdata/profile-activation/or.yaml
@@ -1,0 +1,20 @@
+version: v1beta10
+profiles:
+  - name: one
+    activation:
+      - env:
+          FOO: "true"
+      - env:
+          BAR: "true"
+    patches:
+      - op: replace
+        path: deployments
+        value:
+        - name: test
+          kubectl:
+            manifests:
+              - test.yaml
+        - name: test2
+          kubectl:
+            manifests:
+              - test2.yaml

--- a/e2e/new/tests/config/testdata/profile-activation/profiles.yaml
+++ b/e2e/new/tests/config/testdata/profile-activation/profiles.yaml
@@ -1,0 +1,64 @@
+version: v1beta10
+deployments:
+- name: test
+  kubectl:
+    manifests:
+      - test.yaml
+profiles:
+  - name: one
+    activation:
+      - env:
+          FOO: "true"
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test1
+          kubectl:
+            manifests:
+              - test1.yaml
+  - name: two
+    activation:
+      - env:
+          FOO: "true"
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test2
+          kubectl:
+            manifests:
+              - test2.yaml
+  - name: three
+    activation:
+      - env:
+          FOO: "true"
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test3
+          kubectl:
+            manifests:
+              - test3.yaml
+  - name: four
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test4
+          kubectl:
+            manifests:
+              - test4.yaml
+  - name: five
+    activation:
+      - env:
+          FOO: "true"
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test5
+          kubectl:
+            manifests:
+              - test5.yaml

--- a/e2e/new/tests/config/testdata/profile-activation/regexp.yaml
+++ b/e2e/new/tests/config/testdata/profile-activation/regexp.yaml
@@ -1,0 +1,18 @@
+version: v1beta10
+profiles:
+  - name: one
+    activation:
+      - env:
+          FOO: "t.*"
+    patches:
+      - op: replace
+        path: deployments
+        value:
+        - name: test
+          kubectl:
+            manifests:
+              - test.yaml
+        - name: test2
+          kubectl:
+            manifests:
+              - test2.yaml

--- a/e2e/new/tests/dependencies/dependencies.go
+++ b/e2e/new/tests/dependencies/dependencies.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/loft-sh/devspace/e2e/new/framework"
+	"github.com/loft-sh/devspace/pkg/devspace/config/loader"
 	"github.com/loft-sh/devspace/pkg/util/survey"
 	"github.com/onsi/ginkgo"
 )
@@ -77,6 +78,25 @@ var _ = DevSpaceDescribe("dependencies", func() {
 		framework.ExpectEqual(len(dependencies), 1)
 		framework.ExpectEqual(dependencies[0].Name(), "nested")
 		framework.ExpectEqual(len(dependencies[0].Config().Config().Deployments), 2)
+	})
+
+	ginkgo.It("should resolve dependencies and deactivate activated dependency profiles with --disable-profile-activation", func() {
+		tempDir, err := framework.CopyToTempDir("tests/dependencies/testdata/profile-activation")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		// load activated dependencies with --disable-profile-activation
+		os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO")
+		_, dependencies, err := framework.LoadConfigWithOptions(f, filepath.Join(tempDir, "activated.yaml"), &loader.ConfigOptions{
+			DisableProfileActivation: true,
+		})
+		framework.ExpectNoError(err)
+
+		// check if dependencies were loaded correctly with profile activation
+		framework.ExpectEqual(len(dependencies), 1)
+		framework.ExpectEqual(dependencies[0].Name(), "nested")
+		framework.ExpectEqual(len(dependencies[0].Config().Config().Deployments), 1)
 	})
 
 	ginkgo.It("should resolve dependencies and deactivate dependency profiles", func() {

--- a/e2e/new/tests/dependencies/dependencies.go
+++ b/e2e/new/tests/dependencies/dependencies.go
@@ -61,4 +61,38 @@ var _ = DevSpaceDescribe("dependencies", func() {
 		framework.ExpectEqual(len(dependencies), 1)
 		framework.ExpectEqual(dependencies[0].Name(), "flat")
 	})
+
+	ginkgo.It("should resolve dependencies and activate dependency profiles", func() {
+		tempDir, err := framework.CopyToTempDir("tests/dependencies/testdata/profile-activation")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		// load it from the regular path first
+		os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO")
+		_, dependencies, err := framework.LoadConfig(f, filepath.Join(tempDir, "activated.yaml"))
+		framework.ExpectNoError(err)
+
+		// check if dependencies were loaded correctly with profile activation
+		framework.ExpectEqual(len(dependencies), 1)
+		framework.ExpectEqual(dependencies[0].Name(), "nested")
+		framework.ExpectEqual(len(dependencies[0].Config().Config().Deployments), 2)
+	})
+
+	ginkgo.It("should resolve dependencies and deactivate dependency profiles", func() {
+		tempDir, err := framework.CopyToTempDir("tests/dependencies/testdata/profile-activation")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		// load it from the regular path first
+		os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO")
+		_, dependencies, err := framework.LoadConfig(f, filepath.Join(tempDir, "deactivated.yaml"))
+		framework.ExpectNoError(err)
+
+		// check if dependencies were loaded correctly without profile activation
+		framework.ExpectEqual(len(dependencies), 1)
+		framework.ExpectEqual(dependencies[0].Name(), "nested")
+		framework.ExpectEqual(len(dependencies[0].Config().Config().Deployments), 1)
+	})
 })

--- a/e2e/new/tests/dependencies/dependencies.go
+++ b/e2e/new/tests/dependencies/dependencies.go
@@ -8,6 +8,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader"
 	"github.com/loft-sh/devspace/pkg/util/survey"
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 var _ = DevSpaceDescribe("dependencies", func() {
@@ -114,5 +115,15 @@ var _ = DevSpaceDescribe("dependencies", func() {
 		framework.ExpectEqual(len(dependencies), 1)
 		framework.ExpectEqual(dependencies[0].Name(), "nested")
 		framework.ExpectEqual(len(dependencies[0].Config().Config().Deployments), 1)
+	})
+
+	ginkgo.FIt("should throw error when profile, profiles, and profile-parents are used together", func() {
+		tempDir, err := framework.CopyToTempDir("tests/dependencies/testdata/profiles")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		_, _, err = framework.LoadConfig(f, filepath.Join(tempDir, "validate-error.yaml"))
+		framework.ExpectError(err)
+		framework.Expect(err).Should(gomega.MatchError("dependencies[0].profiles and dependencies[0].profile & dependencies[0].profileParents cannot be used together"))
 	})
 })

--- a/e2e/new/tests/dependencies/testdata/profile-activation/activated.yaml
+++ b/e2e/new/tests/dependencies/testdata/profile-activation/activated.yaml
@@ -1,0 +1,12 @@
+version: v1beta10
+deployments:
+- name: nginx
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: nginx
+dependencies:
+  - name: nested
+    source:
+      path: dep1

--- a/e2e/new/tests/dependencies/testdata/profile-activation/deactivated.yaml
+++ b/e2e/new/tests/dependencies/testdata/profile-activation/deactivated.yaml
@@ -1,0 +1,13 @@
+version: v1beta10
+deployments:
+- name: nginx
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: nginx
+dependencies:
+  - name: nested
+    disableProfileActivation: true
+    source:
+      path: dep1

--- a/e2e/new/tests/dependencies/testdata/profile-activation/dep1/devspace.yaml
+++ b/e2e/new/tests/dependencies/testdata/profile-activation/dep1/devspace.yaml
@@ -1,0 +1,21 @@
+version: v1beta10
+deployments:
+- name: nginx
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: nginx
+profiles:
+  - name: one
+    activation:
+      - env:
+          FOO: "true"
+    patches:
+      - op: add
+        path: deployments
+        value:
+          name: test
+          kubectl:
+            manifests:
+              - test.yaml

--- a/e2e/new/tests/dependencies/testdata/profiles/dep1/dev.yaml
+++ b/e2e/new/tests/dependencies/testdata/profiles/dep1/dev.yaml
@@ -1,0 +1,8 @@
+version: v1beta10
+deployments:
+- name: nginx
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: nginx

--- a/e2e/new/tests/dependencies/testdata/profiles/validate-error.yaml
+++ b/e2e/new/tests/dependencies/testdata/profiles/validate-error.yaml
@@ -1,0 +1,20 @@
+version: v1beta10
+deployments:
+- name: nginx
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: nginx
+dependencies:
+  - name: nested
+    profile: one
+    profiles:
+      - one
+      - two
+    profileParents:
+      - three
+      - four
+    source:
+      path: dep1
+      configName: dev.yaml

--- a/pkg/devspace/config/loader/loader.go
+++ b/pkg/devspace/config/loader/loader.go
@@ -304,7 +304,7 @@ func (l *configLoader) parseConfig(rawConfig map[interface{}]interface{}, parser
 
 func (l *configLoader) applyProfiles(data map[interface{}]interface{}, options *ConfigOptions, log log.Logger) (map[interface{}]interface{}, error) {
 	// Get profile
-	profiles, err := versions.ParseProfile(filepath.Dir(l.configPath), data, options.Profile, options.ProfileParents, options.ProfileRefresh, log)
+	profiles, err := versions.ParseProfile(filepath.Dir(l.configPath), data, options.Profile, options.ProfileParents, options.ProfileRefresh, options.DisableProfileActivation, log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/config/loader/loader_test.go
+++ b/pkg/devspace/config/loader/loader_test.go
@@ -117,11 +117,11 @@ func TestClone(t *testing.T) {
 		cloneTestCase{
 			name: "Clone ConfigOptions",
 			cloner: ConfigOptions{
-				Profile:     "clonerProf",
+				Profiles:    []string{"clonerProf"},
 				KubeContext: "clonerContext",
 			},
 			expectedClone: &ConfigOptions{
-				Profile:     "clonerProf",
+				Profiles:    []string{"clonerProf"},
 				KubeContext: "clonerContext",
 			},
 		},
@@ -670,7 +670,7 @@ profiles:
 			component:
 				containers:
 				- image: ubuntu`,
-				options: &ConfigOptions{Profile: "testprofile"},
+				options: &ConfigOptions{Profiles: []string{"testprofile"}},
 				generatedConfig: &generated.Config{Vars: map[string]string{
 					"test_var": "test",
 				}},
@@ -720,7 +720,7 @@ profiles:
 	- op: replace
 		path: deployments[0].name
 		value: ${test_var_2}`,
-				options: &ConfigOptions{Profile: "testprofile", Vars: []string{"test_var=ubuntu"}},
+				options: &ConfigOptions{Profiles: []string{"testprofile"}, Vars: []string{"test_var=ubuntu"}},
 				generatedConfig: &generated.Config{Vars: map[string]string{
 					"test_var_2": "test",
 				}},
@@ -817,7 +817,7 @@ profiles:
 	- op: replace
 		path: vars[0].name
 		value: new`,
-				options:         &ConfigOptions{Profile: "testprofile"},
+				options:         &ConfigOptions{Profiles: []string{"testprofile"}},
 				generatedConfig: &generated.Config{Vars: map[string]string{"new": "newdefault"}},
 			},
 			expected: &latest.Config{
@@ -902,7 +902,7 @@ profiles:
 	- op: replace
 		path: deployments[0].name
 		value: replaced2`,
-				options:         &ConfigOptions{Profile: "test"},
+				options:         &ConfigOptions{Profiles: []string{"test"}},
 				generatedConfig: &generated.Config{Vars: map[string]string{}},
 			},
 			expected: &latest.Config{
@@ -959,7 +959,7 @@ profiles:
 	- op: replace
 		path: deployments[1].name
 		value: replaced2`,
-				options:         &ConfigOptions{Profile: "test"},
+				options:         &ConfigOptions{Profiles: []string{"test"}},
 				generatedConfig: &generated.Config{Vars: map[string]string{}},
 			},
 			expectedErr: true,
@@ -1003,7 +1003,7 @@ profiles:
         values:
           containers:
           - image: test123/test123`,
-				options:         &ConfigOptions{Profile: "test"},
+				options:         &ConfigOptions{Profiles: []string{"test"}},
 				generatedConfig: &generated.Config{Vars: map[string]string{}},
 			},
 			expected: &latest.Config{
@@ -1068,7 +1068,7 @@ profiles:
   - op: replace
     path: dev.ports.name=devbackend.imageSelector
     value: john/prodbackend`,
-				options:         &ConfigOptions{Profile: "production"},
+				options:         &ConfigOptions{Profiles: []string{"production"}},
 				generatedConfig: &generated.Config{Vars: map[string]string{}},
 			},
 			expected: &latest.Config{
@@ -1108,7 +1108,7 @@ profiles:
   - op: replace
     path: dev.sync.name=devbackend.imageSelector
     value: john/prodbackend`,
-				options:         &ConfigOptions{Profile: "production"},
+				options:         &ConfigOptions{Profiles: []string{"production"}},
 				generatedConfig: &generated.Config{Vars: map[string]string{}},
 			},
 			expected: &latest.Config{

--- a/pkg/devspace/config/loader/options.go
+++ b/pkg/devspace/config/loader/options.go
@@ -27,9 +27,7 @@ type ConfigOptions struct {
 	// path where the base config was loaded from
 	BasePath string
 	// The profile that should be loaded
-	Profile string
-	// If specified profiles that should be loaded before the actual profile
-	ProfileParents []string
+	Profiles []string
 	// If the profile parents that are loaded from other sources should be refreshed
 	ProfileRefresh bool
 	// If the profile activations should be disabled

--- a/pkg/devspace/config/loader/options.go
+++ b/pkg/devspace/config/loader/options.go
@@ -32,6 +32,8 @@ type ConfigOptions struct {
 	ProfileParents []string
 	// If the profile parents that are loaded from other sources should be refreshed
 	ProfileRefresh bool
+	// If the profile activations should be disabled
+	DisableProfileActivation bool
 
 	Vars []string
 

--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -2,6 +2,9 @@ package loader
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
+
 	jsonyaml "github.com/ghodss/yaml"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/helm/merge"
@@ -10,8 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	k8sv1 "k8s.io/api/core/v1"
-	"path/filepath"
-	"strings"
 )
 
 // ValidInitialSyncStrategy checks if strategy is valid
@@ -131,6 +132,9 @@ func validateDependencies(config *latest.Config) error {
 		}
 		if dep.Source.Git == "" && dep.Source.Path == "" {
 			return errors.Errorf("dependencies[%d].source.git or dependencies[%d].source.path is required", index, index)
+		}
+		if len(dep.Profiles) > 0 && (dep.Profile != "" || len(dep.ProfileParents) > 0) {
+			return errors.Errorf("dependencies[%d].profiles and dependencies[%d].profile & dependencies[%d].profileParents cannot be used together", index, index, index)
 		}
 	}
 

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1130,6 +1130,7 @@ type ProfileConfig struct {
 	Replace        *ProfileConfigStructure `yaml:"replace,omitempty" json:"replace,omitempty"`
 	Merge          *ProfileConfigStructure `yaml:"merge,omitempty" json:"merge,omitempty"`
 	StrategicMerge *ProfileConfigStructure `yaml:"strategicMerge,omitempty" json:"strategicMerge,omitempty"`
+	Activation     []*ProfileActivation    `yaml:"activation,omitempty" json:"activation,omitempty"`
 }
 
 // ProfileConfigStructure is the base structure used to validate profiles
@@ -1148,6 +1149,13 @@ type ProfileConfigStructure struct {
 type ProfileParent struct {
 	Source  *SourceConfig `yaml:"source,omitempty" json:"source,omitempty"`
 	Profile string        `yaml:"profile" json:"profile"`
+}
+
+// ProfileActivation defines rules that automatically activate a profile when evaluated to true
+type ProfileActivation struct {
+	// Environment defines key/value pairs where the key is the name of the environment variable and the value is a regular expression used to match the variable's value.
+	// When multiple keys are specified, they must all evaluate to true to activate the profile.
+	Environment map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 }
 
 // PatchConfig describes a config patch and how it should be applied

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -903,16 +903,17 @@ type PodPatch struct {
 
 // DependencyConfig defines the devspace dependency
 type DependencyConfig struct {
-	Name               string          `yaml:"name" json:"name"`
-	Source             *SourceConfig   `yaml:"source" json:"source"`
-	Profile            string          `yaml:"profile,omitempty" json:"profile,omitempty"`
-	ProfileParents     []string        `yaml:"profileParents,omitempty" json:"profileParents,omitempty"`
-	Vars               []DependencyVar `yaml:"vars,omitempty" json:"vars,omitempty"`
-	OverwriteVars      *bool           `yaml:"overwriteVars,omitempty" json:"overwriteVars,omitempty"`
-	SkipBuild          bool            `yaml:"skipBuild,omitempty" json:"skipBuild,omitempty"`
-	IgnoreDependencies bool            `yaml:"ignoreDependencies,omitempty" json:"ignoreDependencies,omitempty"`
-	Namespace          string          `yaml:"namespace,omitempty" json:"namespace,omitempty"`
-	Dev                *DependencyDev  `yaml:"dev,omitempty" json:"dev,omitempty"`
+	Name                     string          `yaml:"name" json:"name"`
+	Source                   *SourceConfig   `yaml:"source" json:"source"`
+	Profile                  string          `yaml:"profile,omitempty" json:"profile,omitempty"`
+	ProfileParents           []string        `yaml:"profileParents,omitempty" json:"profileParents,omitempty"`
+	DisableProfileActivation bool            `yaml:"disableProfileActivation,omitempty" json:"disableProfileActivation,omitempty"`
+	Vars                     []DependencyVar `yaml:"vars,omitempty" json:"vars,omitempty"`
+	OverwriteVars            *bool           `yaml:"overwriteVars,omitempty" json:"overwriteVars,omitempty"`
+	SkipBuild                bool            `yaml:"skipBuild,omitempty" json:"skipBuild,omitempty"`
+	IgnoreDependencies       bool            `yaml:"ignoreDependencies,omitempty" json:"ignoreDependencies,omitempty"`
+	Namespace                string          `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Dev                      *DependencyDev  `yaml:"dev,omitempty" json:"dev,omitempty"`
 }
 
 // DependencyDev specifies which parts of the dependency dev config should

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -906,6 +906,7 @@ type DependencyConfig struct {
 	Name                     string          `yaml:"name" json:"name"`
 	Source                   *SourceConfig   `yaml:"source" json:"source"`
 	Profile                  string          `yaml:"profile,omitempty" json:"profile,omitempty"`
+	Profiles                 []string        `yaml:"profiles,omitempty" json:"profiles,omitempty"`
 	ProfileParents           []string        `yaml:"profileParents,omitempty" json:"profileParents,omitempty"`
 	DisableProfileActivation bool            `yaml:"disableProfileActivation,omitempty" json:"disableProfileActivation,omitempty"`
 	Vars                     []DependencyVar `yaml:"vars,omitempty" json:"vars,omitempty"`

--- a/pkg/devspace/config/versions/util/contains.go
+++ b/pkg/devspace/config/versions/util/contains.go
@@ -1,0 +1,11 @@
+package util
+
+// Contains checks if a match is in the string slice, starting at the given index
+func Contains(strings []string, predicate func(int, string) bool, idx int) bool {
+	for i, s := range strings[idx:] {
+		if predicate(i, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/devspace/config/versions/util/filter.go
+++ b/pkg/devspace/config/versions/util/filter.go
@@ -1,0 +1,11 @@
+package util
+
+// Filter removes matching strings from a string slice
+func Filter(strings []string, predicate func(int, string) bool) (ret []string) {
+	for i, s := range strings {
+		if predicate(i, s) {
+			ret = append(ret, s)
+		}
+	}
+	return
+}

--- a/pkg/devspace/config/versions/versions.go
+++ b/pkg/devspace/config/versions/versions.go
@@ -306,7 +306,7 @@ func getActivatedProfiles(data map[interface{}]interface{}) ([]string, error) {
 	// Convert to array
 	profiles, ok := data["profiles"].([]interface{})
 	if !ok {
-		return activatedProfiles, errors.Errorf("Couldn't load profiles '%s': no profiles found")
+		return activatedProfiles, errors.Errorf("Couldn't load profiles: no profiles found")
 	}
 
 	// Select which profiles are activated

--- a/pkg/devspace/config/versions/versions.go
+++ b/pkg/devspace/config/versions/versions.go
@@ -53,7 +53,7 @@ var versionLoader = map[string]*loader{
 }
 
 // ParseProfile loads the base config & a certain profile
-func ParseProfile(basePath string, data map[interface{}]interface{}, profile string, profileParents []string, update bool, log log.Logger) ([]map[interface{}]interface{}, error) {
+func ParseProfile(basePath string, data map[interface{}]interface{}, profile string, profileParents []string, update bool, disableProfileActivation bool, log log.Logger) ([]map[interface{}]interface{}, error) {
 	profiles := []map[interface{}]interface{}{}
 	if len(profileParents) > 0 && profile == "" {
 		profile = profileParents[len(profileParents)-1]
@@ -61,11 +61,13 @@ func ParseProfile(basePath string, data map[interface{}]interface{}, profile str
 	}
 
 	// auto activated root level profiles
-	activatedProfiles, err := getActivatedProfiles(data)
-	if err != nil {
-		return nil, err
+	if !disableProfileActivation {
+		activatedProfiles, err := getActivatedProfiles(data)
+		if err != nil {
+			return nil, err
+		}
+		profileParents = append(activatedProfiles, profileParents...)
 	}
-	profileParents = append(activatedProfiles, profileParents...)
 
 	// explicitly activated profile
 	if err := getProfiles(basePath, data, profile, &profiles, 1, update, log); err != nil {

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -210,8 +210,12 @@ func (r *resolver) resolveDependency(basePath string, dependency *latest.Depende
 	}
 
 	// set dependency profile
-	cloned.Profile = dependency.Profile
-	cloned.ProfileParents = dependency.ProfileParents
+	cloned.Profiles = []string{}
+	cloned.Profiles = append(cloned.Profiles, dependency.ProfileParents...)
+	if dependency.Profile != "" {
+		cloned.Profiles = append(cloned.Profiles, dependency.Profile)
+	}
+	cloned.Profiles = append(cloned.Profiles, dependency.Profiles...)
 	cloned.DisableProfileActivation = dependency.DisableProfileActivation || r.ConfigOptions.DisableProfileActivation
 
 	// construct load path
@@ -306,7 +310,7 @@ func (r *resolver) resolveDependency(basePath string, dependency *latest.Depende
 
 		kubeClient:     client,
 		dockerClient:   dockerClient,
-		generatedSaver: generated.NewConfigLoaderFromDevSpacePath(dependency.Profile, configPath),
+		generatedSaver: generated.NewConfigLoaderFromDevSpacePath(loader.GetLastProfile(cloned.Profiles), configPath),
 	}, nil
 }
 

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -212,6 +212,7 @@ func (r *resolver) resolveDependency(basePath string, dependency *latest.Depende
 	// set dependency profile
 	cloned.Profile = dependency.Profile
 	cloned.ProfileParents = dependency.ProfileParents
+	cloned.DisableProfileActivation = dependency.DisableProfileActivation
 
 	// construct load path
 	configPath := filepath.Join(localPath, constants.DefaultConfigPath)

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -212,7 +212,7 @@ func (r *resolver) resolveDependency(basePath string, dependency *latest.Depende
 	// set dependency profile
 	cloned.Profile = dependency.Profile
 	cloned.ProfileParents = dependency.ProfileParents
-	cloned.DisableProfileActivation = dependency.DisableProfileActivation
+	cloned.DisableProfileActivation = dependency.DisableProfileActivation || r.ConfigOptions.DisableProfileActivation
 
 	// construct load path
 	configPath := filepath.Join(localPath, constants.DefaultConfigPath)


### PR DESCRIPTION
### Changes
- Auto activate profiles based on environment variables
- Add global `--disable-profile-activation` flag to disable 
- Add `disableProfileActivation` for dependencies

### TODO
- [x] docs
- [x] test regex evaluations
- [x] test dependency `disableProfileActivation` with `--disable-profile-activation`
- [x] avoid duplicate profile activations