### PR TITLE
refactor: refactor dependency sync & ports call

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -24,6 +24,7 @@ type BuildCmd struct {
 	SkipPush                bool
 	SkipPushLocalKubernetes bool
 	VerboseDependencies     bool
+	SkipDependency          []string
 	Dependency              []string
 
 	ForceBuild          bool
@@ -58,6 +59,7 @@ Builds all defined images and pushes them
 	buildCmd.Flags().BoolVar(&cmd.VerboseDependencies, "verbose-dependencies", true, "Builds the dependencies verbosely")
 
 	buildCmd.Flags().StringSliceVarP(&cmd.Tags, "tag", "t", []string{}, "Use the given tag for all built images")
+	buildCmd.Flags().StringSliceVar(&cmd.SkipDependency, "skip-dependency", []string{}, "Skips building the following dependencies")
 	buildCmd.Flags().StringSliceVar(&cmd.Dependency, "dependency", []string{}, "Builds only the specific named dependencies")
 
 	buildCmd.Flags().BoolVar(&cmd.SkipPush, "skip-push", false, "Skips image pushing, useful for minikube deployment")
@@ -128,6 +130,7 @@ func (cmd *BuildCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 	// Dependencies
 	dependencies, err := f.NewDependencyManager(configInterface, client, configOptions, log).BuildAll(dependency.BuildOptions{
 		Dependencies:            cmd.Dependency,
+		SkipDependencies:        cmd.SkipDependency,
 		ForceDeployDependencies: cmd.ForceDependencies,
 		Verbose:                 cmd.VerboseDependencies,
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -41,6 +41,7 @@ type DeployCmd struct {
 	SkipPush                bool
 	SkipPushLocalKubernetes bool
 	Dependency              []string
+	SkipDependency          []string
 
 	Wait    bool
 	Timeout int
@@ -92,6 +93,7 @@ devspace deploy --kube-context=deploy-context
 	deployCmd.Flags().BoolVar(&cmd.SkipDeploy, "skip-deploy", false, "Skips deploying and only builds images")
 	deployCmd.Flags().StringVar(&cmd.Deployments, "deployments", "", "Only deploy a specifc deployment (You can specify multiple deployments comma-separated")
 
+	deployCmd.Flags().StringSliceVar(&cmd.SkipDependency, "skip-dependency", []string{}, "Skips deploying the following dependencies")
 	deployCmd.Flags().StringSliceVar(&cmd.Dependency, "dependency", []string{}, "Deploys only the specific named dependencies")
 
 	deployCmd.Flags().BoolVar(&cmd.Wait, "wait", false, "If true will wait for pods to be running or fails after given timeout")
@@ -186,6 +188,7 @@ func (cmd *DeployCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd
 	// deploy dependencies
 	dependencies, err := f.NewDependencyManager(configInterface, client, configOptions, cmd.log).DeployAll(dependency.DeployOptions{
 		Dependencies:            cmd.Dependency,
+		SkipDependencies:        cmd.SkipDependency,
 		ForceDeployDependencies: cmd.ForceDependencies,
 		SkipBuild:               cmd.SkipBuild,
 		SkipDeploy:              cmd.SkipDeploy,

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -50,6 +50,9 @@ type DevCmd struct {
 	VerboseDependencies     bool
 	Open                    bool
 
+	Dependency     []string
+	SkipDependency []string
+
 	ForceBuild          bool
 	SkipBuild           bool
 	BuildSequential     bool
@@ -115,6 +118,8 @@ Open terminal instead of logs:
 		},
 	}
 
+	devCmd.Flags().StringSliceVar(&cmd.SkipDependency, "skip-dependency", []string{}, "Skips the following dependencies for deployment")
+	devCmd.Flags().StringSliceVar(&cmd.Dependency, "dependency", []string{}, "Deploys only the specified named dependencies")
 	devCmd.Flags().BoolVar(&cmd.VerboseDependencies, "verbose-dependencies", true, "Deploys the dependencies verbosely")
 	devCmd.Flags().BoolVar(&cmd.ForceDependencies, "force-dependencies", true, "Forces to re-evaluate dependencies (use with --force-build --force-deploy to actually force building & deployment of dependencies)")
 
@@ -265,6 +270,8 @@ func (cmd *DevCmd) buildAndDeploy(f factory.Factory, configInterface config.Conf
 			SkipBuild:               cmd.SkipBuild,
 			ForceDeploy:             cmd.ForceDeploy,
 			Verbose:                 cmd.VerboseDependencies,
+			Dependencies:            cmd.Dependency,
+			SkipDependencies:        cmd.SkipDependency,
 
 			BuildOptions: build.Options{
 				SkipPush:                  cmd.SkipPush,

--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -7,16 +7,15 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/devspace/docker"
+	"github.com/loft-sh/devspace/pkg/devspace/server"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
 	"github.com/loft-sh/devspace/pkg/util/survey"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/loft-sh/devspace/pkg/devspace/plugin"
-	"github.com/loft-sh/devspace/pkg/devspace/server"
 	"github.com/loft-sh/devspace/pkg/devspace/services"
 	"github.com/loft-sh/devspace/pkg/devspace/upgrade"
 
@@ -279,9 +278,6 @@ func (cmd *DevCmd) buildAndDeploy(f factory.Factory, configInterface config.Conf
 			return 0, errors.Errorf("error deploying dependencies: %v", err)
 		}
 
-		// add dev config from dependencies
-		addDependenciesDevConfig(config, dependencies)
-
 		// Create Pull Secrets
 		err = pullsecrets.NewClient(configInterface, dependencies, client, dockerClient, cmd.log).CreatePullSecrets()
 		if err != nil {
@@ -407,16 +403,13 @@ func (cmd *DevCmd) startServices(f factory.Factory, configInterface config.Confi
 	if err != nil {
 		return 0, err
 	}
-
-	if cmd.Portforwarding {
-		cmd.Portforwarding = false
-		err := servicesClient.StartPortForwarding(cmd.Interrupt)
-		if err != nil {
-			return 0, errors.Errorf("Unable to start portforwarding: %v", err)
+	for _, d := range dependencies {
+		if d.DependencyConfig().Dev == nil || d.DependencyConfig().Dev.ReplacePods == false {
+			continue
 		}
-		err = servicesClient.StartReversePortForwarding(cmd.Interrupt)
+		err = d.ReplacePods(client, logger)
 		if err != nil {
-			return 0, errors.Errorf("Unable to start portforwarding: %v", err)
+			return 0, err
 		}
 	}
 
@@ -433,17 +426,51 @@ func (cmd *DevCmd) startServices(f factory.Factory, configInterface config.Confi
 
 		// Create server
 		uiLogger := log.GetFileLogger("ui")
-		server, err := server.NewServer(configInterface, dependencies, "localhost", false, client.CurrentContext(), client.Namespace(), port, uiLogger)
+		serv, err := server.NewServer(configInterface, dependencies, "localhost", false, client.CurrentContext(), client.Namespace(), port, uiLogger)
+		logger.StopWait()
 		if err != nil {
 			logger.Warnf("Couldn't start UI server: %v", err)
 		} else {
 			// Start server
-			go func() { server.ListenAndServe() }()
+			go func() { serv.ListenAndServe() }()
 
-			logger.StopWait()
 			logger.WriteString("\n#########################################################\n")
-			logger.Infof("DevSpace UI available at: %s", ansi.Color("http://"+server.Server.Addr, "white+b"))
+			logger.Infof("DevSpace UI available at: %s", ansi.Color("http://"+serv.Server.Addr, "white+b"))
 			logger.WriteString("#########################################################\n\n")
+		}
+	}
+
+	if cmd.Portforwarding {
+		cmd.Portforwarding = false
+
+		// start port forwarding
+		err := servicesClient.StartPortForwarding(cmd.Interrupt)
+		if err != nil {
+			return 0, errors.Errorf("Unable to start portforwarding: %v", err)
+		}
+		for _, d := range dependencies {
+			if d.DependencyConfig().Dev == nil || d.DependencyConfig().Dev.Ports == false {
+				continue
+			}
+			err = d.StartPortForwarding(client, cmd.Interrupt, logger)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		// start reverse port forwarding
+		err = servicesClient.StartReversePortForwarding(cmd.Interrupt)
+		if err != nil {
+			return 0, errors.Errorf("Unable to start portforwarding: %v", err)
+		}
+		for _, d := range dependencies {
+			if d.DependencyConfig().Dev == nil || d.DependencyConfig().Dev.Ports == false {
+				continue
+			}
+			err = d.StartReversePortForwarding(client, cmd.Interrupt, logger)
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 
@@ -454,9 +481,20 @@ func (cmd *DevCmd) startServices(f factory.Factory, configInterface config.Confi
 			printSyncLog = true
 		}
 
-		err := servicesClient.StartSync(cmd.Interrupt, printSyncLog, cmd.VerboseSync)
+		err := servicesClient.StartSync(cmd.Interrupt, printSyncLog, cmd.VerboseSync, services.DefaultPrefixFn)
 		if err != nil {
 			return 0, errors.Wrap(err, "start sync")
+		}
+
+		// start in dependencies
+		for _, d := range dependencies {
+			if d.DependencyConfig().Dev == nil || d.DependencyConfig().Dev.Sync == false {
+				continue
+			}
+			err = d.StartSync(client, cmd.Interrupt, printSyncLog, cmd.VerboseSync, logger)
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 
@@ -754,70 +792,4 @@ func updateLastKubeContext(configLoader loader.ConfigLoader, client kubectl.Clie
 	}
 
 	return nil
-}
-
-func addDependenciesDevConfig(config *latest.Config, dependencies []types.Dependency) {
-	for _, d := range config.Dependencies {
-		if d.Dev == nil {
-			continue
-		}
-
-		// find the dependency in the deployed ones and it
-		for _, e := range dependencies {
-			if e.Name() != d.Name {
-				continue
-			}
-
-			// ports
-			if d.Dev != nil && d.Dev.Ports {
-				for _, p := range e.Config().Config().Dev.Ports {
-					if config.Dev.Ports == nil {
-						config.Dev.Ports = []*latest.PortForwardingConfig{}
-					}
-
-					imageName := p.ImageName
-					if imageName != "" {
-						imageName = e.Name() + "." + imageName
-					}
-
-					config.Dev.Ports = append(config.Dev.Ports, &latest.PortForwardingConfig{
-						ImageName:           imageName,
-						ImageSelector:       p.ImageSelector,
-						LabelSelector:       p.LabelSelector,
-						ContainerName:       p.ContainerName,
-						Namespace:           p.Namespace,
-						Arch:                p.Arch,
-						PortMappings:        p.PortMappings,
-						PortMappingsReverse: p.PortMappingsReverse,
-					})
-				}
-			}
-
-			// sync
-			if d.Dev != nil && d.Dev.Sync == true {
-				for _, p := range e.Config().Config().Dev.Sync {
-					if config.Dev.Sync == nil {
-						config.Dev.Sync = []*latest.SyncConfig{}
-					}
-
-					// set the correct image name
-					imageName := p.ImageName
-					if imageName != "" {
-						imageName = e.Name() + "." + imageName
-					}
-
-					// set the correct local sub path
-					if p.LocalSubPath != "" {
-						p.LocalSubPath = filepath.Join(e.LocalPath(), p.LocalSubPath)
-					} else {
-						p.LocalSubPath = e.LocalPath()
-					}
-
-					config.Dev.Sync = append(config.Dev.Sync, p)
-				}
-			}
-
-			break
-		}
-	}
 }

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -26,7 +26,8 @@ type PurgeCmd struct {
 	PurgeDependencies   bool
 	All                 bool
 
-	Dependency []string
+	SkipDependency []string
+	Dependency     []string
 
 	log log.Logger
 }
@@ -62,6 +63,7 @@ devspace purge -d my-deployment
 	purgeCmd.Flags().BoolVar(&cmd.PurgeDependencies, "dependencies", false, "DEPRECATED: Please use --all instead")
 	purgeCmd.Flags().BoolVar(&cmd.VerboseDependencies, "verbose-dependencies", true, "Builds the dependencies verbosely")
 
+	purgeCmd.Flags().StringSliceVar(&cmd.SkipDependency, "skip-dependency", []string{}, "Skips the following dependencies from purging")
 	purgeCmd.Flags().StringSliceVar(&cmd.Dependency, "dependency", []string{}, "Purges only the specific named dependencies")
 
 	return purgeCmd
@@ -129,8 +131,9 @@ func (cmd *PurgeCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd 
 	var dependencies []types.Dependency
 	if cmd.All || len(cmd.Dependency) > 0 {
 		dependencies, err = f.NewDependencyManager(configInterface, client, configOptions, cmd.log).PurgeAll(dependency.PurgeOptions{
-			Dependencies: cmd.Dependency,
-			Verbose:      cmd.VerboseDependencies,
+			SkipDependencies: cmd.SkipDependency,
+			Dependencies:     cmd.Dependency,
+			Verbose:          cmd.VerboseDependencies,
 		})
 		if err != nil {
 			cmd.log.Errorf("Error purging dependencies: %v", err)

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -39,6 +39,7 @@ type RenderCmd struct {
 	Deployments string
 
 	SkipDependencies bool
+	SkipDependency   []string
 	Dependency       []string
 
 	Writer io.Writer
@@ -78,6 +79,7 @@ deployment.
 	renderCmd.Flags().StringVar(&cmd.Deployments, "deployments", "", "Only deploy a specifc deployment (You can specify multiple deployments comma-separated")
 
 	renderCmd.Flags().BoolVar(&cmd.SkipDependencies, "skip-dependencies", false, "Skips rendering the dependencies")
+	renderCmd.Flags().StringSliceVar(&cmd.SkipDependency, "skip-dependency", []string{}, "Skips rendering the following dependencies")
 	renderCmd.Flags().StringSliceVar(&cmd.Dependency, "dependency", []string{}, "Renders only the specific named dependencies")
 
 	return renderCmd
@@ -146,10 +148,11 @@ func (cmd *RenderCmd) Run(f factory.Factory, plugins []plugin.Metadata, cobraCmd
 	var dependencies []types.Dependency
 	if cmd.SkipDependencies == false {
 		dependencies, err = f.NewDependencyManager(configInterface, client, configOptions, log).RenderAll(dependency.RenderOptions{
-			Dependencies: cmd.Dependency,
-			SkipBuild:    cmd.SkipBuild,
-			Verbose:      cmd.VerboseDependencies,
-			Writer:       cmd.Writer,
+			Dependencies:     cmd.Dependency,
+			SkipDependencies: cmd.SkipDependency,
+			SkipBuild:        cmd.SkipBuild,
+			Verbose:          cmd.VerboseDependencies,
+			Writer:           cmd.Writer,
 
 			BuildOptions: build.Options{
 				SkipPush:                  cmd.SkipPush,

--- a/cmd/reset/pods.go
+++ b/cmd/reset/pods.go
@@ -109,9 +109,9 @@ func (cmd *podsCmd) RunResetPods(f factory.Factory, cobraCmd *cobra.Command, arg
 // ResetPods deletes the pods created by dev.replacePods
 func ResetPods(client kubectl.Client, config config.Config, dependencies []dependencytypes.Dependency, log log.Logger) {
 	// create pod replacer
-	podReplacer := podreplace.NewPodReplacer()
 	resetted := 0
 	errored := false
+	podReplacer := podreplace.NewPodReplacer()
 	for _, replacePod := range config.Config().Dev.ReplacePods {
 		deletedPod, err := podReplacer.RevertReplacePod(context.TODO(), client, config, dependencies, replacePod, log)
 		if err != nil {

--- a/e2e/new/tests/dependencies/dependencies.go
+++ b/e2e/new/tests/dependencies/dependencies.go
@@ -1,6 +1,8 @@
 package dependencies
 
 import (
+	"fmt"
+	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
 
@@ -24,6 +26,23 @@ var _ = DevSpaceDescribe("dependencies", func() {
 
 	ginkgo.BeforeEach(func() {
 		f = framework.NewDefaultFactory()
+	})
+
+	ginkgo.It("should resolve dependencies with dev configuration and hooks", func() {
+		tempDir, err := framework.CopyToTempDir("tests/dependencies/testdata/dev-sync")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		// load it from the regular path first
+		config, dependencies, err := framework.LoadConfig(f, filepath.Join(tempDir, "devspace.yaml"))
+		framework.ExpectNoError(err)
+
+		// check if dependencies were loaded correctly
+		framework.ExpectEqual(len(dependencies), 1)
+		framework.ExpectEqual(dependencies[0].Name(), "dep1")
+
+		out, _ := yaml.Marshal(config.Config().Dev.Sync)
+		fmt.Println(string(out))
 	})
 
 	ginkgo.It("should resolve dependencies with local path and nested structure", func() {

--- a/e2e/new/tests/dependencies/testdata/dev-sync/dep1.yaml
+++ b/e2e/new/tests/dependencies/testdata/dev-sync/dep1.yaml
@@ -1,0 +1,14 @@
+version: v1beta10
+images:
+  test:
+    image: abc/abc
+    tags:
+      - dep2
+dev:
+  sync:
+    - name: test
+      imageSelector: image(test):tag(test)
+dependencies:
+  - name: dep2
+    source:
+      path: dep2.yaml

--- a/e2e/new/tests/dependencies/testdata/dev-sync/dep2.yaml
+++ b/e2e/new/tests/dependencies/testdata/dev-sync/dep2.yaml
@@ -1,0 +1,1 @@
+version: v1beta10

--- a/e2e/new/tests/dependencies/testdata/dev-sync/devspace.yaml
+++ b/e2e/new/tests/dependencies/testdata/dev-sync/devspace.yaml
@@ -1,0 +1,13 @@
+version: v1beta10
+images: 
+  test:
+    image: abc/abc
+    tags:
+      - latest
+dependencies:
+  - name: dep1
+    source:
+      path: dep1.yaml
+    dev:
+      sync: true
+      ports: true

--- a/pkg/devspace/command/command.go
+++ b/pkg/devspace/command/command.go
@@ -40,7 +40,7 @@ func ExecuteCommand(commands []*latest.CommandConfig, name string, args []string
 		}
 
 		// execute the command in a shell
-		return shell.ExecuteShellCommand(shellCommand, args, stdout, stderr, nil)
+		return shell.ExecuteShellCommand(shellCommand, args, "", stdout, stderr, nil)
 	}
 
 	shellArgs = append(shellArgs, args...)

--- a/pkg/devspace/config/loader/variable/command_variable.go
+++ b/pkg/devspace/config/loader/variable/command_variable.go
@@ -48,7 +48,7 @@ func execCommand(varName string, definition *latest.Variable, cmd string, args [
 	stdErrWriter := &bytes.Buffer{}
 	var err error
 	if args == nil {
-		err = shell.ExecuteShellCommand(cmd, nil, writer, stdErrWriter, nil)
+		err = shell.ExecuteShellCommand(cmd, nil, "", writer, stdErrWriter, nil)
 	} else {
 		err = command.ExecuteCommand(cmd, args, writer, stdErrWriter)
 	}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -927,6 +927,10 @@ type DependencyDev struct {
 	// If sync is true, DevSpace will run the specified sync paths
 	// from the dependency's dev.sync config
 	Sync bool `yaml:"sync,omitempty" json:"sync,omitempty"`
+
+	// If replacePods is true, DevSpace will replace the specified pods
+	// from the dependency's dev.replacePods config
+	ReplacePods bool `yaml:"replacePods,omitempty" json:"replacePods,omitempty"`
 }
 
 // DependencyVar holds an override value for a config variable

--- a/pkg/devspace/config/versions/versions.go
+++ b/pkg/devspace/config/versions/versions.go
@@ -249,7 +249,8 @@ func getProfiles(basePath string, data map[interface{}]interface{}, profile stri
 					}
 
 					if profileConfig.Parents[i].Source != nil {
-						_, localPath, err := dependencyutil.DownloadDependency(basePath, profileConfig.Parents[i].Source, profileConfig.Parents[i].Profile, nil, update, log)
+						ID := dependencyutil.GetParentProfileID(basePath, profileConfig.Parents[i].Source, profileConfig.Parents[i].Profile, nil)
+						localPath, err := dependencyutil.DownloadDependency(ID, basePath, profileConfig.Parents[i].Source, update, log)
 						if err != nil {
 							return err
 						}

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -260,7 +260,7 @@ func (m *manager) AddHelmDeployment(deploymentName string) error {
 				m.log.WriteString("\n")
 				m.log.Infof("Cloning external repo `%s` containing to retrieve Helm chart", gitRepo)
 
-				err = shell.ExecuteShellCommand(gitCommand, nil, os.Stdout, os.Stderr, nil)
+				err = shell.ExecuteShellCommand(gitCommand, nil, "", os.Stdout, os.Stderr, nil)
 				if err != nil {
 					m.log.WriteString("\n")
 					m.log.Errorf("Unable to clone repository `%s` (branch: %s)", gitRepo, gitBranch)

--- a/pkg/devspace/dependency/resolver_test.go
+++ b/pkg/devspace/dependency/resolver_test.go
@@ -124,7 +124,7 @@ func TestResolver(t *testing.T) {
 			},
 			expectedDependencies: []Dependency{
 				Dependency{
-					id:        "https://github.com/devspace-cloud/example-dependency.git@f8b2aa8cf8ac03238a28e8f78382b214d619893f:mysubpath",
+					id:        "6f6b8b240599fff48a4009c3f78825881deb0306ab09c8ae3e10bf5bef390325",
 					localPath: filepath.Join(util.DependencyFolderPath, "84e3f5121aa5a99b3d26752f40e3935f494312ad82d0e85afc9b6e23c762c705", "mysubpath"),
 				},
 			},
@@ -231,7 +231,7 @@ func TestGetDependencyID(t *testing.T) {
 					Tag: "myTag",
 				},
 			},
-			expectedID: "someTagGit@myTag",
+			expectedID: "2255ee093fea082d8f3cdc8095a723bb0d1104c1b28a017b636ff4aaa806a064",
 		},
 		getDependencyIDTestCase{
 			name: "git with branch",
@@ -241,7 +241,7 @@ func TestGetDependencyID(t *testing.T) {
 					Branch: "myBranch",
 				},
 			},
-			expectedID: "someBranchGit@myBranch",
+			expectedID: "6a475ccc660b39e1f8e7b701a206a19e9347457b0ee80910b3fece44a2867598",
 		},
 		getDependencyIDTestCase{
 			name: "git with revision, subpath and profile",
@@ -253,19 +253,20 @@ func TestGetDependencyID(t *testing.T) {
 				},
 				Profile: "myProfile",
 			},
-			expectedID: "someRevisionGit@myRevision:mySubPath - profile myProfile",
+			expectedID: "947020214d9a41c68c3947e5fdbaf3d0541fca84ceee9a7b7bbf5300fb053f9e",
 		},
 		getDependencyIDTestCase{
 			name: "empty",
 			dependency: &latest.DependencyConfig{
 				Source: &latest.SourceConfig{},
 			},
-			expectedID: "",
+			expectedID: "5c7bed9afdec33b1d734b7dce7666bc43c5d389373af94a463b1aaebac61f013",
 		},
 	}
 
 	for _, testCase := range testCases {
-		id := util.GetDependencyID(testCase.baseBath, testCase.dependency.Source, testCase.dependency.Profile, nil)
+		id, err := util.GetDependencyID(testCase.baseBath, testCase.dependency)
+		assert.NilError(t, err)
 		assert.Equal(t, testCase.expectedID, id, "Dependency has wrong id in testCase %s", testCase.name)
 	}
 }

--- a/pkg/devspace/dependency/resolver_test.go
+++ b/pkg/devspace/dependency/resolver_test.go
@@ -1,6 +1,7 @@
 package dependency
 
 import (
+	"github.com/loft-sh/devspace/pkg/util/hash"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,6 +32,7 @@ type resolverTestCase struct {
 	updateParam     bool
 	allowCyclic     bool
 
+	skipIds              bool
 	expectedDependencies []Dependency
 	expectedErr          string
 }
@@ -98,11 +100,9 @@ func TestResolver(t *testing.T) {
 			},
 			expectedDependencies: []Dependency{
 				Dependency{
-					id:        filepath.Join(dir, "dependency1"),
 					localPath: filepath.Join(dir, "dependency1"),
 				},
 				Dependency{
-					id:        filepath.Join(dir, "dependency2"),
 					localPath: filepath.Join(dir, "dependency2"),
 				},
 			},
@@ -124,21 +124,39 @@ func TestResolver(t *testing.T) {
 			},
 			expectedDependencies: []Dependency{
 				Dependency{
-					id:        "6f6b8b240599fff48a4009c3f78825881deb0306ab09c8ae3e10bf5bef390325",
-					localPath: filepath.Join(util.DependencyFolderPath, "84e3f5121aa5a99b3d26752f40e3935f494312ad82d0e85afc9b6e23c762c705", "mysubpath"),
+					localPath: filepath.Join(util.DependencyFolderPath, hash.String(mustGetDependencyID(dir, &latest.DependencyConfig{
+						Name: "test",
+						Source: &latest.SourceConfig{
+							Git:      "https://github.com/devspace-cloud/example-dependency.git",
+							Revision: "f8b2aa8cf8ac03238a28e8f78382b214d619893f",
+							SubPath:  "mysubpath",
+						},
+					})), "mysubpath"),
 				},
 			},
 		},
 		resolverTestCase{
-			name: "Cyclic allowed dependency",
+			name:    "Cyclic allowed dependency",
+			skipIds: true,
 			files: map[string]*latest.Config{
+				"dependency2/devspace.yaml": &latest.Config{
+					Version: latest.Version,
+					Dependencies: []*latest.DependencyConfig{
+						&latest.DependencyConfig{
+							Name: "test",
+							Source: &latest.SourceConfig{
+								Path: "../dependency1",
+							},
+						},
+					},
+				},
 				"dependency1/devspace.yaml": &latest.Config{
 					Version: latest.Version,
 					Dependencies: []*latest.DependencyConfig{
 						&latest.DependencyConfig{
 							Name: "test",
 							Source: &latest.SourceConfig{
-								Path: "..",
+								Path: "../dependency2",
 							},
 						},
 					},
@@ -155,7 +173,9 @@ func TestResolver(t *testing.T) {
 			allowCyclic: true,
 			expectedDependencies: []Dependency{
 				Dependency{
-					id:        filepath.Join(dir, "dependency1"),
+					localPath: filepath.Join(dir, "dependency2"),
+				},
+				Dependency{
 					localPath: filepath.Join(dir, "dependency1"),
 				},
 			},
@@ -190,7 +210,10 @@ func TestResolver(t *testing.T) {
 
 		assert.Equal(t, len(testCase.expectedDependencies), len(dependencies), "Wrong dependency length in testCase %s", testCase.name)
 		for index, expected := range testCase.expectedDependencies {
-			assert.Equal(t, expected.id, dependencies[index].id, "Dependency has wrong id in testCase %s", testCase.name)
+			if testCase.skipIds == false {
+				id, _ := util.GetDependencyID(dir, testCase.dependencyTasks[index])
+				assert.Equal(t, id, dependencies[index].id, "Dependency has wrong id in testCase %s", testCase.name)
+			}
 			assert.Equal(t, expected.localPath, dependencies[index].localPath, "Dependency has wrong local path in testCase %s", testCase.name)
 		}
 
@@ -201,6 +224,11 @@ func TestResolver(t *testing.T) {
 		os.RemoveAll(util.DependencyFolderPath) //No error catch because it doesn't need to exist
 
 	}
+}
+
+func mustGetDependencyID(basePath string, config *latest.DependencyConfig) string {
+	id, _ := util.GetDependencyID(basePath, config)
+	return id
 }
 
 func includes(arr []string, needle string) bool {
@@ -231,7 +259,7 @@ func TestGetDependencyID(t *testing.T) {
 					Tag: "myTag",
 				},
 			},
-			expectedID: "2255ee093fea082d8f3cdc8095a723bb0d1104c1b28a017b636ff4aaa806a064",
+			expectedID: "e8fb9810c53ca0986d12ec5d078e38659a1700425a292cefe4f77bffa351667c",
 		},
 		getDependencyIDTestCase{
 			name: "git with branch",
@@ -241,7 +269,7 @@ func TestGetDependencyID(t *testing.T) {
 					Branch: "myBranch",
 				},
 			},
-			expectedID: "6a475ccc660b39e1f8e7b701a206a19e9347457b0ee80910b3fece44a2867598",
+			expectedID: "9a5ed87e8fec108a03b592058f7eec3a0b1c9fe431cfe1d03a5d37333fb07b2d",
 		},
 		getDependencyIDTestCase{
 			name: "git with revision, subpath and profile",
@@ -253,14 +281,14 @@ func TestGetDependencyID(t *testing.T) {
 				},
 				Profile: "myProfile",
 			},
-			expectedID: "947020214d9a41c68c3947e5fdbaf3d0541fca84ceee9a7b7bbf5300fb053f9e",
+			expectedID: "bb783d78de53d3bcb1533d239a3d1d685070f22b9f25e5c487a83425be586900",
 		},
 		getDependencyIDTestCase{
 			name: "empty",
 			dependency: &latest.DependencyConfig{
 				Source: &latest.SourceConfig{},
 			},
-			expectedID: "5c7bed9afdec33b1d734b7dce7666bc43c5d389373af94a463b1aaebac61f013",
+			expectedID: "cc4af1ccc6f0bba9d05b89a8ac9bfdca135653f86d9535756b8c219bc7fdd9a1",
 		},
 	}
 

--- a/pkg/devspace/dependency/types/types.go
+++ b/pkg/devspace/dependency/types/types.go
@@ -3,6 +3,8 @@ package types
 import (
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/util/log"
 )
 
 type Dependency interface {
@@ -11,6 +13,9 @@ type Dependency interface {
 
 	// Name will return the dependency name
 	Name() string
+
+	// Config holds the dependency config
+	Config() config.Config
 
 	// Children returns dependency children if any
 	Children() []Dependency
@@ -24,9 +29,18 @@ type Dependency interface {
 	// BuiltImages returns the images that were built by this dependency
 	BuiltImages() map[string]string
 
-	// Config holds the dependency config
-	Config() config.Config
-
 	// DependencyConfig is the config this dependency was created from
 	DependencyConfig() *latest.DependencyConfig
+
+	// ReplacePods replaces the dependencies pods from dev.replacePods
+	ReplacePods(client kubectl.Client, logger log.Logger) error
+
+	// StartSync starts the dependency sync
+	StartSync(client kubectl.Client, interrupt chan error, printSyncLog, verboseSync bool, logger log.Logger) error
+
+	// StartPortForwarding starts the dependency port-forwarding
+	StartPortForwarding(client kubectl.Client, interrupt chan error, logger log.Logger) error
+
+	// StartReversePortForwarding starts the dependency port-forwarding
+	StartReversePortForwarding(client kubectl.Client, interrupt chan error, logger log.Logger) error
 }

--- a/pkg/devspace/hook/download.go
+++ b/pkg/devspace/hook/download.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/pkg/errors"
 	"io"
@@ -23,7 +24,7 @@ func NewDownloadHook() RemoteHook {
 
 type remoteDownloadHook struct{}
 
-func (r *remoteDownloadHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *kubectl.SelectedPodContainer, log logpkg.Logger) error {
+func (r *remoteDownloadHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error {
 	containerPath := "."
 	if hook.Download.ContainerPath != "" {
 		containerPath = hook.Download.ContainerPath

--- a/pkg/devspace/hook/local_command.go
+++ b/pkg/devspace/hook/local_command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/util/shell"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 func NewLocalCommandHook(stdout io.Writer, stderr io.Writer) Hook {
@@ -40,12 +41,13 @@ func (l *localCommandHook) Execute(ctx Context, hook *latest.HookConfig, config 
 	if ctx.Error != nil {
 		extraEnv[ErrorEnv] = ctx.Error.Error()
 	}
+	dir := filepath.Dir(config.Path())
 
 	// if args are nil we execute the command in a shell
 	if hook.Args == nil {
-		return shell.ExecuteShellCommand(hook.Command, nil, l.Stdout, l.Stderr, extraEnv)
+		return shell.ExecuteShellCommand(hook.Command, nil, dir, l.Stdout, l.Stderr, extraEnv)
 	}
 
 	// else we execute it directly
-	return command.ExecuteCommandWithEnv(hook.Command, hook.Args, l.Stdout, l.Stderr, extraEnv)
+	return command.ExecuteCommandWithEnv(hook.Command, hook.Args, dir, l.Stdout, l.Stderr, extraEnv)
 }

--- a/pkg/devspace/hook/logs.go
+++ b/pkg/devspace/hook/logs.go
@@ -3,7 +3,7 @@ package hook
 import (
 	"context"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
-	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"io"
 )
@@ -18,7 +18,7 @@ type remoteLogsHook struct {
 	Writer io.Writer
 }
 
-func (r *remoteLogsHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *kubectl.SelectedPodContainer, log logpkg.Logger) error {
+func (r *remoteLogsHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error {
 	reader, err := ctx.Client.Logs(context.TODO(), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name, false, hook.Logs.TailLines, true)
 	if err != nil {
 		return err

--- a/pkg/devspace/hook/remote_command.go
+++ b/pkg/devspace/hook/remote_command.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/pkg/errors"
 	"io"
@@ -20,7 +21,7 @@ type remoteCommandHook struct {
 	Stderr io.Writer
 }
 
-func (r *remoteCommandHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *kubectl.SelectedPodContainer, log logpkg.Logger) error {
+func (r *remoteCommandHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error {
 	cmd := []string{hook.Command}
 	if hook.Args == nil {
 		cmd = []string{"sh", "-c", hook.Command}

--- a/pkg/devspace/hook/remote_hook.go
+++ b/pkg/devspace/hook/remote_hook.go
@@ -6,7 +6,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
-	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
@@ -18,7 +18,7 @@ import (
 
 // RemoteHook is a hook that is executed in a container
 type RemoteHook interface {
-	ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *kubectl.SelectedPodContainer, log logpkg.Logger) error
+	ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error
 }
 
 func NewRemoteHook(hook RemoteHook) Hook {
@@ -104,7 +104,7 @@ func (r *remoteHook) execute(ctx Context, hook *latest.HookConfig, imageSelector
 	// select the container
 	targetSelector := targetselector.NewTargetSelector(ctx.Client)
 	podContainer, err := targetSelector.SelectSingleContainer(context.TODO(), targetselector.Options{
-		Selector: kubectl.Selector{
+		Selector: selector.Selector{
 			ImageSelector: imageSelector,
 			LabelSelector: labelSelector,
 			Pod:           hook.Where.Container.Pod,
@@ -113,8 +113,8 @@ func (r *remoteHook) execute(ctx Context, hook *latest.HookConfig, imageSelector
 		},
 		Wait:            &wait,
 		Timeout:         timeout,
-		SortPods:        kubectl.SortPodsByNewest,
-		SortContainers:  kubectl.SortContainersByNewest,
+		SortPods:        selector.SortPodsByNewest,
+		SortContainers:  selector.SortContainersByNewest,
 		WaitingStrategy: r.WaitingStrategy,
 	}, log)
 	if err != nil {

--- a/pkg/devspace/hook/upload.go
+++ b/pkg/devspace/hook/upload.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/pkg/errors"
 	"io"
@@ -21,7 +22,7 @@ func NewUploadHook() RemoteHook {
 
 type remoteUploadHook struct{}
 
-func (r *remoteUploadHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *kubectl.SelectedPodContainer, log logpkg.Logger) error {
+func (r *remoteUploadHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error {
 	containerPath := "."
 	if hook.Upload.ContainerPath != "" {
 		containerPath = hook.Upload.ContainerPath

--- a/pkg/devspace/hook/wait.go
+++ b/pkg/devspace/hook/wait.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/util"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
 	"github.com/loft-sh/devspace/pkg/util/imageselector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
@@ -82,7 +83,7 @@ func (r *waitHook) execute(ctx Context, hook *latest.HookConfig, imageSelector [
 
 	// wait until the defined condition will be true, this will wait initially 2 seconds
 	err := wait.Poll(time.Second*2, time.Duration(timeout)*time.Second, func() (done bool, err error) {
-		podContainers, err := kubectl.NewFilter(ctx.Client).SelectContainers(context.TODO(), kubectl.Selector{
+		podContainers, err := selector.NewFilter(ctx.Client).SelectContainers(context.TODO(), selector.Selector{
 			ImageSelector: imageSelector,
 			LabelSelector: labelSelector,
 			Pod:           hook.Where.Container.Pod,
@@ -116,7 +117,7 @@ func (r *waitHook) execute(ctx Context, hook *latest.HookConfig, imageSelector [
 	return nil
 }
 
-func isWaitConditionTrue(condition *latest.HookWaitConfig, podContainer *kubectl.SelectedPodContainer) bool {
+func isWaitConditionTrue(condition *latest.HookWaitConfig, podContainer *selector.SelectedPodContainer) bool {
 	if podContainer.Pod.DeletionTimestamp != nil {
 		return false
 	}

--- a/pkg/devspace/services/client.go
+++ b/pkg/devspace/services/client.go
@@ -21,7 +21,7 @@ type Client interface {
 
 	StartPortForwarding(interrupt chan error) error
 	StartReversePortForwarding(interrupt chan error) error
-	StartSync(interrupt chan error, printSyncLog bool, verboseSync bool) error
+	StartSync(interrupt chan error, printSyncLog bool, verboseSync bool, prefixFn func(idx int, syncConfig *latest.SyncConfig) string) error
 
 	StartSyncFromCmd(options targetselector.Options, syncConfig *latest.SyncConfig, interrupt chan error, verbose bool) error
 	StartTerminal(options targetselector.Options, args []string, workDir string, interrupt chan error, wait bool) (int, error)

--- a/pkg/devspace/services/targetselector/until_newest_running.go
+++ b/pkg/devspace/services/targetselector/until_newest_running.go
@@ -2,6 +2,7 @@ package targetselector
 
 import (
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	"github.com/loft-sh/devspace/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
 	"sort"
@@ -38,7 +39,7 @@ func (u *untilNewestRunning) SelectPod(pods []*v1.Pod, log log.Logger) (bool, *v
 	}
 
 	sort.Slice(pods, func(i, j int) bool {
-		return kubectl.SortPodsByNewest(pods, i, j)
+		return selector.SortPodsByNewest(pods, i, j)
 	})
 	if HasPodProblem(pods[0]) {
 		u.printPodWarning(pods[0], log)
@@ -51,7 +52,7 @@ func (u *untilNewestRunning) SelectPod(pods []*v1.Pod, log log.Logger) (bool, *v
 	return true, pods[0], nil
 }
 
-func (u *untilNewestRunning) SelectContainer(containers []*kubectl.SelectedPodContainer, log log.Logger) (bool, *kubectl.SelectedPodContainer, error) {
+func (u *untilNewestRunning) SelectContainer(containers []*selector.SelectedPodContainer, log log.Logger) (bool, *selector.SelectedPodContainer, error) {
 	now := time.Now()
 	if now.Before(u.initialDelay) {
 		return false, nil, nil
@@ -64,7 +65,7 @@ func (u *untilNewestRunning) SelectContainer(containers []*kubectl.SelectedPodCo
 	}
 
 	sort.Slice(containers, func(i, j int) bool {
-		return kubectl.SortContainersByNewest(containers, i, j)
+		return selector.SortContainersByNewest(containers, i, j)
 	})
 	if HasPodProblem(containers[0].Pod) {
 		u.printPodWarning(containers[0].Pod, log)
@@ -90,7 +91,7 @@ func (u *untilNewestRunning) printPodWarning(pod *v1.Pod, log log.Logger) {
 	})
 }
 
-func IsContainerRunning(container *kubectl.SelectedPodContainer) bool {
+func IsContainerRunning(container *selector.SelectedPodContainer) bool {
 	if container.Pod.DeletionTimestamp != nil {
 		return false
 	}

--- a/pkg/devspace/services/targetselector/until_not_terminating.go
+++ b/pkg/devspace/services/targetselector/until_not_terminating.go
@@ -1,7 +1,7 @@
 package targetselector
 
 import (
-	kubectl "github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	"github.com/loft-sh/devspace/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
 	"sort"
@@ -35,7 +35,7 @@ func (u *untilNotTerminating) SelectPod(pods []*v1.Pod, log log.Logger) (bool, *
 	}
 
 	sort.Slice(pods, func(i, j int) bool {
-		return kubectl.SortPodsByNewest(pods, i, j)
+		return selector.SortPodsByNewest(pods, i, j)
 	})
 	if isPodTerminating(pods[0]) {
 		return false, nil, nil
@@ -44,7 +44,7 @@ func (u *untilNotTerminating) SelectPod(pods []*v1.Pod, log log.Logger) (bool, *
 	return true, pods[0], nil
 }
 
-func (u *untilNotTerminating) SelectContainer(containers []*kubectl.SelectedPodContainer, log log.Logger) (bool, *kubectl.SelectedPodContainer, error) {
+func (u *untilNotTerminating) SelectContainer(containers []*selector.SelectedPodContainer, log log.Logger) (bool, *selector.SelectedPodContainer, error) {
 	now := time.Now()
 	if now.Before(u.initialDelay) {
 		return false, nil, nil
@@ -57,7 +57,7 @@ func (u *untilNotTerminating) SelectContainer(containers []*kubectl.SelectedPodC
 	}
 
 	sort.Slice(containers, func(i, j int) bool {
-		return kubectl.SortContainersByNewest(containers, i, j)
+		return selector.SortContainersByNewest(containers, i, j)
 	})
 	if isPodTerminating(containers[0].Pod) {
 		return false, nil, nil

--- a/pkg/devspace/services/targetselector/until_not_waiting.go
+++ b/pkg/devspace/services/targetselector/until_not_waiting.go
@@ -1,7 +1,7 @@
 package targetselector
 
 import (
-	kubectl "github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	"github.com/loft-sh/devspace/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
 	"sort"
@@ -36,7 +36,7 @@ func (u *untilNotWaiting) SelectPod(pods []*v1.Pod, log log.Logger) (bool, *v1.P
 	}
 
 	sort.Slice(pods, func(i, j int) bool {
-		return kubectl.SortPodsByNewest(pods, i, j)
+		return selector.SortPodsByNewest(pods, i, j)
 	})
 	if isPodWaiting(pods[0]) {
 		return false, nil, nil
@@ -45,7 +45,7 @@ func (u *untilNotWaiting) SelectPod(pods []*v1.Pod, log log.Logger) (bool, *v1.P
 	return true, pods[0], nil
 }
 
-func (u *untilNotWaiting) SelectContainer(containers []*kubectl.SelectedPodContainer, log log.Logger) (bool, *kubectl.SelectedPodContainer, error) {
+func (u *untilNotWaiting) SelectContainer(containers []*selector.SelectedPodContainer, log log.Logger) (bool, *selector.SelectedPodContainer, error) {
 	now := time.Now()
 	if now.Before(u.initialDelay) {
 		return false, nil, nil
@@ -58,7 +58,7 @@ func (u *untilNotWaiting) SelectContainer(containers []*kubectl.SelectedPodConta
 	}
 
 	sort.Slice(containers, func(i, j int) bool {
-		return kubectl.SortContainersByNewest(containers, i, j)
+		return selector.SortContainersByNewest(containers, i, j)
 	})
 	if isContainerWaiting(containers[0]) {
 		return false, nil, nil
@@ -77,7 +77,7 @@ func isPodWaiting(pod *v1.Pod) bool {
 	if pod.DeletionTimestamp != nil {
 		return true
 	}
-	
+
 	for _, containerStatus := range pod.Status.InitContainerStatuses {
 		if containerStatus.State.Waiting != nil {
 			return true
@@ -92,11 +92,11 @@ func isPodWaiting(pod *v1.Pod) bool {
 	return false
 }
 
-func isContainerWaiting(container *kubectl.SelectedPodContainer) bool {
+func isContainerWaiting(container *selector.SelectedPodContainer) bool {
 	if container.Pod.DeletionTimestamp != nil {
 		return true
 	}
-	
+
 	for _, containerStatus := range container.Pod.Status.InitContainerStatuses {
 		if containerStatus.Name == container.Container.Name && containerStatus.State.Waiting != nil {
 			return true

--- a/pkg/devspace/services/targetselector/waiting_strategy.go
+++ b/pkg/devspace/services/targetselector/waiting_strategy.go
@@ -1,13 +1,13 @@
 package targetselector
 
 import (
-	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	"github.com/loft-sh/devspace/pkg/util/log"
 	v1 "k8s.io/api/core/v1"
 )
 
 // WaitingStrategy defines how the target selector should wait
 type WaitingStrategy interface {
-	SelectContainer(containers []*kubectl.SelectedPodContainer, log log.Logger) (bool, *kubectl.SelectedPodContainer, error)
+	SelectContainer(containers []*selector.SelectedPodContainer, log log.Logger) (bool, *selector.SelectedPodContainer, error)
 	SelectPod(pods []*v1.Pod, log log.Logger) (bool, *v1.Pod, error)
 }

--- a/pkg/devspace/sync/tar.go
+++ b/pkg/devspace/sync/tar.go
@@ -163,7 +163,9 @@ func (u *Unarchiver) untarNext(destPath string, tarReader *tar.Reader) (bool, er
 			}
 		}
 
-		out, err := exec.Command(u.syncConfig.Options.FileChangeCmd, cmdArgs...).CombinedOutput()
+		cmd := exec.Command(u.syncConfig.Options.FileChangeCmd, cmdArgs...)
+		cmd.Dir = u.syncConfig.LocalPath
+		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return false, errors.Errorf("Error executing command '%s %s': %s => %v", u.syncConfig.Options.FileChangeCmd, strings.Join(cmdArgs, " "), string(out), err)
 		}
@@ -210,7 +212,9 @@ func (u *Unarchiver) createAllFolders(name string, perm os.FileMode) error {
 				}
 			}
 
-			out, err := exec.Command(u.syncConfig.Options.DirCreateCmd, cmdArgs...).CombinedOutput()
+			cmd := exec.Command(u.syncConfig.Options.DirCreateCmd, cmdArgs...)
+			cmd.Dir = u.syncConfig.LocalPath
+			out, err := cmd.CombinedOutput()
 			if err != nil {
 				return errors.Errorf("Error executing command '%s %s': %s => %v", u.syncConfig.Options.DirCreateCmd, strings.Join(cmdArgs, " "), string(out), err)
 			}

--- a/pkg/util/shell/shell.go
+++ b/pkg/util/shell/shell.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-func ExecuteShellCommand(command string, args []string, stdout io.Writer, stderr io.Writer, extraEnvVars map[string]string) error {
+func ExecuteShellCommand(command string, args []string, dir string, stdout io.Writer, stderr io.Writer, extraEnvVars map[string]string) error {
 	env := os.Environ()
 	for k, v := range extraEnvVars {
 		env = append(env, k+"="+v)
@@ -24,13 +24,15 @@ func ExecuteShellCommand(command string, args []string, stdout io.Writer, stderr
 	}
 
 	// Get current working directory
-	pwd, err := os.Getwd()
-	if err != nil {
-		return err
+	if dir == "" {
+		dir, err = os.Getwd()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create shell runner
-	r, err := interp.New(interp.Dir(pwd), interp.StdIO(os.Stdin, stdout, stderr), interp.Env(expand.ListEnviron(env...)))
+	r, err := interp.New(interp.Dir(dir), interp.StdIO(os.Stdin, stdout, stderr), interp.Env(expand.ListEnviron(env...)))
 	if err != nil {
 		return errors.Wrap(err, "create shell runner")
 	}


### PR DESCRIPTION
### Changes
- New option `dependencies[*].dev.replacePods` to enable replace pods from dependencies
- New flag `--skip-dependency` for `devspace build`, `devspace dev`, `devspace purge`, `devspace deploy` & `devspace render`