### PR TITLE
feat: use files for excluding paths from synchronization

### DIFF
--- a/docs/pages/configuration/development/file-synchronization.mdx
+++ b/docs/pages/configuration/development/file-synchronization.mdx
@@ -324,8 +324,46 @@ dev:
     - '!/my-folder-2/'
 ```
 **Explanation:**  
-- All files will be execluded except those in folders `./my-folder-1/` and `./my-folder-2/`
+- All files will be excluded except those in folders `./my-folder-1/` and `./my-folder-2/`
 
+### `excludeFile`
+The `excludeFile` option expects a path to a file from which the exclude paths can be loaded. Once loaded, the behavior is identical to the `excludePaths` option. This is useful for sharing a common list of exclude paths between many components. The earlier example, [Exclude Paths from Synchronization](#example-exclude-paths-from-synchronization), can be converted to files as follows:
+
+#### Example: Exclude Paths from Synchronization using files
+```yaml {14-20}
+images:
+  backend:
+    image: john/devbackend
+deployments:
+- name: app-backend
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: john/devbackend
+dev:
+  sync:
+  - imageSelector: john/devbackend
+    excludeFile: .gitignore
+    uploadExcludeFile: upload.gitignore
+    downloadExcludeFile: download.gitignore
+```
+
+#### Example: `.gitignore`
+```
+log/
+more/logs/
+```
+
+#### Example: `upload.gitignore`
+```
+node_modules/
+```
+
+#### Example: `download.gitignore`
+```
+tmp/
+```
 
 ### `downloadExcludePaths`
 The `downloadExcludePaths` option expects an array of strings with paths that should not be synchronized from the remote container filesystem to the local filesystem.
@@ -337,6 +375,17 @@ downloadExcludePaths: [] # Do not exclude anything from file synchronization
 
 #### Example
 **See "[Example: Exclude Paths from Synchronization](#example-exclude-paths-from-synchronization)"**
+
+### `downloadExcludeFile`
+The `downloadExcludeFile` option expects a path to a file from which the exclude paths can be loaded. These paths should not be synchronized from the remote container filesystem to the local filesystem.
+
+#### Default Value For `downloadExcludeFile`
+```yaml
+downloadExcludeFile: "" # Do not load exclude paths from a file
+```
+
+#### Example
+**See "[Example: Exclude Paths from Synchronization using files](#example-exclude-paths-from-synchronization-using-files)"**
 
 ### `uploadExcludePaths`
 The `uploadExcludePaths` option expects an array of strings with paths that should not be synchronized from the local filesystem to the remote container filesystem.
@@ -353,6 +402,16 @@ uploadExcludePaths: [] # Do not exclude anything from file synchronization
 #### Example
 **See "[Example: Exclude Paths from Synchronization](#example-exclude-paths-from-synchronization)"**
 
+### `uploadExcludeFile`
+The `uploadExcludeFile` option expects a path to a file from which the exclude paths can be loaded. These paths should not be synchronized from the local filesystem to the remote container filesystem.
+
+#### Default Value For `uploadExcludeFile`
+```yaml
+uploadExcludeFile: "" # Do not load exclude paths from a file
+```
+
+#### Example
+**See "[Example: Exclude Paths from Synchronization using files](#example-exclude-paths-from-synchronization-using-files)"**
 
 <br/>
 

--- a/docs/pages/configuration/reference.mdx
+++ b/docs/pages/configuration/reference.mdx
@@ -268,8 +268,11 @@ sync:                               # struct[] | Array of file sync settings for
   disableUpload: false              # bool     | If true will disable uploading files
   containerPath: /app               # string   | Path in the container that should be synchronized with localSubPath (Default is working directory of container ("."))
   excludePaths: []                  # string[] | Paths to exclude files/folders from sync in .gitignore syntax
+  excludeFile : ""                  # string   | Path to a file using .gitignore syntax to exclude files/folders from sync
   downloadExcludePaths: []          # string[] | Paths to exclude files/folders from download in .gitignore syntax
+  downloadExcludeFile : ""          # string   | Path to a file using .gitignore syntax to exclude files/folders from download
   uploadExcludePaths: []            # string[] | Paths to exclude files/folders from upload in .gitignore syntax
+  uploadExcludeFile : ""            # string   | Path to a file using .gitignore syntax to exclude files/folders from upload
   initialSync: mirrorLocal          # enum     | Specifies the initialSync algorithm: mirrorLocal, mirrorRemote, preferLocal, preferRemote, preferNewest, keepAll (Default: mirrorLocal)
   initialSyncCompareBy: mtime       # enum     | Specifies how the initialSync determines if a file has changed: mtime / size
   waitInitialSync: false            # bool     | Wait until initial sync is completed before continuing (Default: false)

--- a/e2e/new/tests/sync/testdata/sync-exclude-file/.gitignore
+++ b/e2e/new/tests/sync/testdata/sync-exclude-file/.gitignore
@@ -1,0 +1,1 @@
+file-exclude.txt

--- a/e2e/new/tests/sync/testdata/sync-exclude-file/.gitignore-download
+++ b/e2e/new/tests/sync/testdata/sync-exclude-file/.gitignore-download
@@ -1,0 +1,1 @@
+file-download-exclude.txt

--- a/e2e/new/tests/sync/testdata/sync-exclude-file/.gitignore-upload
+++ b/e2e/new/tests/sync/testdata/sync-exclude-file/.gitignore-upload
@@ -1,0 +1,1 @@
+file-upload-exclude.txt

--- a/e2e/new/tests/sync/testdata/sync-exclude-file/devspace.yaml
+++ b/e2e/new/tests/sync/testdata/sync-exclude-file/devspace.yaml
@@ -1,0 +1,43 @@
+version: v1beta10
+vars:
+  - name: IMAGE
+    value: node:13.14-alpine
+deployments:
+  - name: test
+    helm:
+      componentChart: true
+      values:
+        containers:
+          - image: ${IMAGE}
+            command: ["sleep"]
+            args: ["999999999999"]
+dev:
+  sync:
+    - name: test
+      imageSelector: ${IMAGE}
+      containerPath: "/app"
+      excludeFile: .gitignore
+      downloadExcludeFile: .gitignore-download
+      uploadExcludeFile: .gitignore-upload
+hooks:
+  - command: mkdir /app
+    where:
+      container:
+        imageSelector: ${IMAGE}
+    when:
+      before:
+        initialSync: test
+  - command: echo -n Hello World > /app/file-download-exclude.txt
+    where:
+      container:
+        imageSelector: ${IMAGE}
+    when:
+      after:
+        initialSync: test
+  - command: echo -n Hello World > /app/initial-sync-done.txt
+    where:
+      container:
+        imageSelector: ${IMAGE}
+    when:
+      after:
+        initialSync: test

--- a/e2e/new/tests/sync/testdata/sync-exclude-file/file-exclude.txt
+++ b/e2e/new/tests/sync/testdata/sync-exclude-file/file-exclude.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/e2e/new/tests/sync/testdata/sync-exclude-file/file-include.txt
+++ b/e2e/new/tests/sync/testdata/sync-exclude-file/file-include.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/e2e/new/tests/sync/testdata/sync-exclude-file/file-upload-exclude.txt
+++ b/e2e/new/tests/sync/testdata/sync-exclude-file/file-upload-exclude.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -741,8 +741,11 @@ type SyncConfig struct {
 	LocalSubPath         string               `yaml:"localSubPath,omitempty" json:"localSubPath,omitempty"`
 	ContainerPath        string               `yaml:"containerPath,omitempty" json:"containerPath,omitempty"`
 	ExcludePaths         []string             `yaml:"excludePaths,omitempty" json:"excludePaths,omitempty"`
+	ExcludeFile          string               `yaml:"excludeFile,omitempty" json:"excludeFile,omitempty"`
 	DownloadExcludePaths []string             `yaml:"downloadExcludePaths,omitempty" json:"downloadExcludePaths,omitempty"`
+	DownloadExcludeFile  string               `yaml:"downloadExcludeFile,omitempty" json:"downloadExcludeFile,omitempty"`
 	UploadExcludePaths   []string             `yaml:"uploadExcludePaths,omitempty" json:"uploadExcludePaths,omitempty"`
+	UploadExcludeFile    string               `yaml:"uploadExcludeFile,omitempty" json:"uploadExcludeFile,omitempty"`
 	InitialSync          InitialSyncStrategy  `yaml:"initialSync,omitempty" json:"initialSync,omitempty"`
 	InitialSyncCompareBy InitialSyncCompareBy `yaml:"initialSyncCompareBy,omitempty" json:"initialSyncCompareBy,omitempty"`
 


### PR DESCRIPTION
### Changes
- Add `excludeFile`, `downloadExcludeFile`, and `uploadExclude` options for loading exclude paths from files using `.gitignore` syntax (#1562)