### PR TITLE
#1632: Add path type to schema

### DIFF
--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -599,6 +599,7 @@ type IngressRuleConfig struct {
 	Path        string `yaml:"path,omitempty" json:"path,omitempty"`
 	ServicePort *int   `yaml:"servicePort,omitempty" json:"servicePort,omitempty"`
 	ServiceName string `yaml:"serviceName,omitempty" json:"serviceName,omitempty"`
+	PathType    string `yaml:"pathType,omitempty" json:"pathType,omitempty"`
 }
 
 // AutoScalingConfig holds the autoscaling config of a component


### PR DESCRIPTION
Resolves #1632 
The ingress parameter "pathType" is mandatory from version 5.15. If the parameter is omitted, the following error appears:

`spec.rules[0].http.paths[0].pathType: Required value: pathType must be specified`

But if try to set it, another error appears:

`field pathType not found in type latest.IngressRuleConfig`

This change adds ability to specify 'pathType' parameter.
