### PR TITLE
Component Chart & UI commands namespace and context

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -17,6 +17,7 @@ type AttachCmd struct {
 	*flags.GlobalFlags
 
 	LabelSelector string
+	ImageSelector string
 	Image         string
 	Container     string
 	Pod           string
@@ -49,6 +50,7 @@ devspace attach -n my-namespace
 
 	attachCmd.Flags().StringVarP(&cmd.Container, "container", "c", "", "Container name within pod where to execute command")
 	attachCmd.Flags().StringVar(&cmd.Pod, "pod", "", "Pod to open a shell to")
+	attachCmd.Flags().StringVar(&cmd.ImageSelector, "image-selector", "", "The image to search a pod for (e.g. nginx, nginx:latest, image(app), nginx:tag(app))")
 	attachCmd.Flags().StringVar(&cmd.Image, "image", "", "Image is the config name of an image to select in the devspace config (e.g. 'default'), it is NOT a docker image like myuser/myimage")
 	attachCmd.Flags().StringVarP(&cmd.LabelSelector, "label-selector", "l", "", "Comma separated key=value selector list (e.g. release=test)")
 
@@ -100,7 +102,7 @@ func (cmd *AttachCmd) Run(f factory.Factory, cobraCmd *cobra.Command, args []str
 	options := targetselector.NewOptionsFromFlags(cmd.Container, cmd.LabelSelector, cmd.Namespace, cmd.Pod, cmd.Pick)
 
 	// get image selector if specified
-	imageSelector, err := getImageSelector(client, configLoader, configOptions, cmd.Image, log)
+	imageSelector, err := getImageSelector(client, configLoader, configOptions, cmd.Image, cmd.ImageSelector, log)
 	if err != nil {
 		return err
 	}

--- a/cmd/set/var.go
+++ b/cmd/set/var.go
@@ -124,7 +124,7 @@ type variableParser struct {
 	Used        map[string]bool
 }
 
-func (v *variableParser) Parse(originalRawConfig map[interface{}]interface{}, rawConfig map[interface{}]interface{}, vars []*latest.Variable, resolver variable.Resolver, options *loader.ConfigOptions, log log.Logger) (*latest.Config, error) {
+func (v *variableParser) Parse(configPath string, originalRawConfig map[interface{}]interface{}, rawConfig map[interface{}]interface{}, vars []*latest.Variable, resolver variable.Resolver, options *loader.ConfigOptions, log log.Logger) (*latest.Config, error) {
 	// Find out what vars are really used
 	varsUsed, err := resolver.FindVariables(rawConfig, vars)
 	if err != nil {

--- a/pkg/devspace/config/loader/expression/expression.go
+++ b/pkg/devspace/config/loader/expression/expression.go
@@ -1,0 +1,95 @@
+package expression
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/kubectl/walk"
+	"github.com/loft-sh/devspace/pkg/util/shell"
+	"gopkg.in/yaml.v2"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ExpressionMatchRegex is the regex to check if a value matches the devspace var format
+var ExpressionMatchRegex = regexp.MustCompile("(?ms)\\$\\#?\\!?\\{\\{(.+?)\\}\\}")
+
+func expressionMatchFn(key, value string) bool {
+	return ExpressionMatchRegex.MatchString(value)
+}
+
+func ResolveAllExpressions(preparedConfig map[interface{}]interface{}, dir string) error {
+	err := walk.Walk(preparedConfig, expressionMatchFn, func(value string) (interface{}, error) {
+		return ResolveExpressions(value, dir)
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ResolveExpressions(value, dir string) (interface{}, error) {
+	matches := ExpressionMatchRegex.FindAllStringSubmatch(value, -1)
+	if len(matches) == 0 {
+		return value, nil
+	}
+
+	out := value
+	for _, match := range matches {
+		if len(match) != 2 {
+			continue
+		}
+
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		err := shell.ExecuteShellCommand(match[1], os.Args[1:], dir, stdout, stderr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error executing config expression %s: %v (stdout: %s, stderr: %s)", match[1], err, stdout.String(), stderr.String())
+		}
+
+		stdOut := stdout.String()
+		if value[1] != '#' {
+			stdOut = strings.TrimSpace(stdOut)
+		}
+
+		out = strings.Replace(out, match[0], stdOut, 1)
+	}
+
+	// try to convert to an object
+	if len(matches) == 1 && len(matches[0][0]) == len(value) && value[1] != '!' && value[2] != '!' {
+		// is boolean?
+		a, err := strconv.ParseBool(out)
+		if err == nil {
+			return a, nil
+		}
+
+		// is int?
+		i, err := strconv.Atoi(out)
+		if err == nil {
+			return i, nil
+		}
+		
+		// is null?
+		if out == "null" || out == "undefined" {
+			return nil, nil
+		}
+		
+		// is yaml object?
+		m := map[interface{}]interface{}{}
+		err = yaml.Unmarshal([]byte(out), &m)
+		if err == nil {
+			return m, nil
+		}
+
+		// is yaml array?
+		arr := []interface{}{}
+		err = yaml.Unmarshal([]byte(out), &arr)
+		if err == nil {
+			return arr, nil
+		}
+	}
+
+	return out, nil
+}

--- a/pkg/devspace/config/loader/loader.go
+++ b/pkg/devspace/config/loader/loader.go
@@ -129,7 +129,7 @@ func (l *configLoader) LoadWithParser(parser Parser, options *ConfigOptions, log
 		return nil, err
 	}
 
-	parsedConfig, generatedConfig, resolver, err := l.parseConfig(data, parser, options, log)
+	parsedConfig, generatedConfig, resolver, err := l.parseConfig(absPath, data, parser, options, log)
 	if err != nil {
 		pluginErr = plugin.ExecutePluginHookWithContext("config.errorLoad", map[string]interface{}{"ERROR": err, "LOAD_PATH": absPath})
 		if pluginErr != nil {
@@ -254,7 +254,7 @@ func (l *configLoader) ensureRequires(config *latest.Config, log log.Logger) err
 	return nil
 }
 
-func (l *configLoader) parseConfig(rawConfig map[interface{}]interface{}, parser Parser, options *ConfigOptions, log log.Logger) (*latest.Config, *generated.Config, variable.Resolver, error) {
+func (l *configLoader) parseConfig(absPath string, rawConfig map[interface{}]interface{}, parser Parser, options *ConfigOptions, log log.Logger) (*latest.Config, *generated.Config, variable.Resolver, error) {
 	// load the generated config
 	generatedConfig, err := l.LoadGenerated(options)
 	if err != nil {
@@ -307,7 +307,7 @@ func (l *configLoader) parseConfig(rawConfig map[interface{}]interface{}, parser
 	delete(copiedRawConfig, "vars")
 
 	// parse the config
-	latestConfig, err := parser.Parse(rawConfig, copiedRawConfig, vars, resolver, options, log)
+	latestConfig, err := parser.Parse(absPath, rawConfig, copiedRawConfig, vars, resolver, options, log)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/devspace/config/loader/loader_test.go
+++ b/pkg/devspace/config/loader/loader_test.go
@@ -1143,7 +1143,7 @@ profiles:
 		testCase.in.options.generatedLoader = &fakeGeneratedLoader{}
 
 		configLoader := NewConfigLoader("").(*configLoader)
-		newConfig, _, _, err := configLoader.parseConfig(testMap, NewDefaultParser(), testCase.in.options, log.Discard)
+		newConfig, _, _, err := configLoader.parseConfig("", testMap, NewDefaultParser(), testCase.in.options, log.Discard)
 		if testCase.expectedErr {
 			if err == nil {
 				t.Fatalf("TestCase %s: expected error, but got none", index)

--- a/pkg/devspace/deploy/deployer/helm/client.go
+++ b/pkg/devspace/deploy/deployer/helm/client.go
@@ -27,7 +27,7 @@ const ComponentChartFolder = "component-chart"
 // DevSpaceChartConfig is the config that holds the devspace chart information
 var DevSpaceChartConfig = &latest.ChartConfig{
 	Name:    "component-chart",
-	Version: "0.8.1",
+	Version: "0.8.2",
 	RepoURL: "https://charts.devspace.sh",
 }
 

--- a/pkg/devspace/hook/download.go
+++ b/pkg/devspace/hook/download.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
@@ -24,7 +26,7 @@ func NewDownloadHook() RemoteHook {
 
 type remoteDownloadHook struct{}
 
-func (r *remoteDownloadHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error {
+func (r *remoteDownloadHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, config config.Config, dependencies []types.Dependency, log logpkg.Logger) error {
 	containerPath := "."
 	if hook.Download.ContainerPath != "" {
 		containerPath = hook.Download.ContainerPath

--- a/pkg/devspace/hook/logs.go
+++ b/pkg/devspace/hook/logs.go
@@ -2,7 +2,9 @@ package hook
 
 import (
 	"context"
+	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"io"
@@ -18,7 +20,7 @@ type remoteLogsHook struct {
 	Writer io.Writer
 }
 
-func (r *remoteLogsHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error {
+func (r *remoteLogsHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, config config.Config, dependencies []types.Dependency, log logpkg.Logger) error {
 	reader, err := ctx.Client.Logs(context.TODO(), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name, false, hook.Logs.TailLines, true)
 	if err != nil {
 		return err

--- a/pkg/devspace/hook/remote_hook.go
+++ b/pkg/devspace/hook/remote_hook.go
@@ -18,7 +18,7 @@ import (
 
 // RemoteHook is a hook that is executed in a container
 type RemoteHook interface {
-	ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error
+	ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, config config.Config, dependencies []types.Dependency, log logpkg.Logger) error
 }
 
 func NewRemoteHook(hook RemoteHook) Hook {
@@ -74,7 +74,7 @@ func (r *remoteHook) Execute(ctx Context, hook *latest.HookConfig, config config
 		}
 	}
 
-	executed, err := r.execute(ctx, hook, imageSelectors, log)
+	executed, err := r.execute(ctx, hook, imageSelectors, config, dependencies, log)
 	if err != nil {
 		return err
 	} else if executed == false {
@@ -84,7 +84,7 @@ func (r *remoteHook) Execute(ctx Context, hook *latest.HookConfig, config config
 	return nil
 }
 
-func (r *remoteHook) execute(ctx Context, hook *latest.HookConfig, imageSelector []imageselector.ImageSelector, log logpkg.Logger) (bool, error) {
+func (r *remoteHook) execute(ctx Context, hook *latest.HookConfig, imageSelector []imageselector.ImageSelector, config config.Config, dependencies []types.Dependency, log logpkg.Logger) (bool, error) {
 	labelSelector := ""
 	if len(hook.Where.Container.LabelSelector) > 0 {
 		labelSelector = labels.Set(hook.Where.Container.LabelSelector).String()
@@ -127,7 +127,7 @@ func (r *remoteHook) execute(ctx Context, hook *latest.HookConfig, imageSelector
 
 	// execute the hook in the container
 	log.Infof("Execute hook '%s' in container '%s/%s/%s'", ansi.Color(hookName(hook), "white+b"), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name)
-	err = r.Hook.ExecuteRemotely(ctx, hook, podContainer, log)
+	err = r.Hook.ExecuteRemotely(ctx, hook, podContainer, config, dependencies, log)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/devspace/hook/upload.go
+++ b/pkg/devspace/hook/upload.go
@@ -3,7 +3,9 @@ package hook
 import (
 	"archive/tar"
 	"compress/gzip"
+	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
@@ -22,7 +24,7 @@ func NewUploadHook() RemoteHook {
 
 type remoteUploadHook struct{}
 
-func (r *remoteUploadHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, log logpkg.Logger) error {
+func (r *remoteUploadHook) ExecuteRemotely(ctx Context, hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, config config.Config, dependencies []types.Dependency, log logpkg.Logger) error {
 	containerPath := "."
 	if hook.Upload.ContainerPath != "" {
 		containerPath = hook.Upload.ContainerPath

--- a/pkg/devspace/server/command.go
+++ b/pkg/devspace/server/command.go
@@ -31,7 +31,7 @@ func (h *handler) command(w http.ResponseWriter, r *http.Request) {
 
 	// Open logs connection
 	stream := &wsStream{WebSocket: ws}
-	cmd := exec.Command("devspace", "run", name[0])
+	cmd := exec.Command("devspace", "--namespace", h.defaultNamespace, "--kube-context", h.defaultContext, "run", name[0])
 	done := make(chan bool)
 	defer close(done)
 

--- a/pkg/util/vars/parse.go
+++ b/pkg/util/vars/parse.go
@@ -6,7 +6,7 @@ import (
 )
 
 // VarMatchRegex is the regex to check if a value matches the devspace var format
-var VarMatchRegex = regexp.MustCompile("(\\$+!?\\{[^\\}]+\\})")
+var VarMatchRegex = regexp.MustCompile("(\\$+!?\\{[^\\{\\}]+\\})")
 
 // ReplaceVarFn defines the replace function
 type ReplaceVarFn func(value string) (interface{}, error)


### PR DESCRIPTION
### Changes
- Fixed an issue where `pathType` was not automatically set for newer ingress versions
- Fixed an issue where namespace and context were wrong in UI commands
- New flag `--image-selector` for commands `devspace enter`, `devspace logs` & `devspace attach`
- You can now use `image(default)` and `tag(default)` in hook commands and args:
```yaml
images:
  test:
    image: test/test
hooks:
  - command: |-
      ./custom-script image(test):tag(test) # -> Transformed to ./custom-script test/test:##### 
    when:
      after:
        images: all
```
- New feature config expressions `${{ any valid bash expression }}` that are evaluated after variables are loaded and can be used to generate certain fields of the devspace yaml dynamically:

Only build if user uses `devspace deploy`
```yaml
images:
  default:
    build: |-
      ${{ 
        if [ "$1" == "deploy" ]; then 
          echo {disabled: false}
        else
          echo {disabled: true}
        fi
      }}
```
Use devspace var to decide if to open terminal
```yaml
vars:
- name: OPEN_TERMINAL
  options:
  - "true"
  - "false"
dev:
  terminal: ${{ [ "${OPEN_TERMINAL}" == "true" ] && echo "{}" || echo "null" }}
```
Use environment variable to decide if to open terminal:
```yaml
dev:
  terminal: ${{ [ "$OPEN_TERMINAL" == "true" ] && echo "{}" || echo "null" }}
```