### PR TITLE
feat: add option to execute hooks once

### DIFF
--- a/docs/pages/configuration/hooks/basics.mdx
+++ b/docs/pages/configuration/hooks/basics.mdx
@@ -237,7 +237,7 @@ hooks:
 
 ## Execute hooks once
 
-Hooks can be executed once per deployment when executing a command in a container. This can be useful for running one-time development tasks without init containers. In the following example, the command would only run once in in all containers running with the image `nginx:1.21`.
+Hooks can be executed only once for each targeted container. This means as long as the container where the hook was executed stays running, the hook will not be executed for this container again until it restarts. This can be useful for running one-time development tasks without using init containers. In the following example, the command would only run once for the newest container running with the image `nginx:1.21`.
 
 ```yaml {8}
 ...
@@ -251,6 +251,8 @@ hooks:
   events: ["after:deploy"]
 ...
 ```
+
+If you run `devspace dev` or `devspace deploy` now multiple times and the container is not replaced or restarted, the hook is only executed once.
 
 ## Hook Context Information
 

--- a/docs/pages/configuration/hooks/basics.mdx
+++ b/docs/pages/configuration/hooks/basics.mdx
@@ -235,6 +235,23 @@ hooks:
   events: ["after:build"]
 ```
 
+## Execute hooks once
+
+Hooks can be executed once per deployment when executing a command in a container. This can be useful for running one-time development tasks without init containers. In the following example, the command would only run once in in all containers running with the image `nginx:1.21`.
+
+```yaml {8}
+...
+hooks:
+- command: |
+    echo Hello World!
+    echo From within the container!
+  container:
+    imageSelector: nginx:1.21
+    once: true
+  events: ["after:deploy"]
+...
+```
+
 ## Hook Context Information
 
 DevSpace passes certain environment variables to the hook execution:

--- a/docs/pages/fragments/config-hooks.mdx
+++ b/docs/pages/fragments/config-hooks.mdx
@@ -31,4 +31,5 @@ hooks:                              # struct[]  | Array of hooks to be executed.
     labelSelector: ...              # struct    | Key Value map of labels and values to select pods with
     containerName: ""               # string    | Container name to use after selecting a pod
     namespace: ""                   # string    | Kubernetes namespace to select pods in
+    once: ""                        # bool      | If true the command will execute once - unless the targeted container is restarted and the hook is re-executing according to its lifecycle events (default false)
 ```

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/loft-sh/devspace/e2e/tests/config"
 	_ "github.com/loft-sh/devspace/e2e/tests/dependencies"
 	_ "github.com/loft-sh/devspace/e2e/tests/deploy"
+	_ "github.com/loft-sh/devspace/e2e/tests/hooks"
 	_ "github.com/loft-sh/devspace/e2e/tests/init"
 	_ "github.com/loft-sh/devspace/e2e/tests/replacepods"
 	_ "github.com/loft-sh/devspace/e2e/tests/sync"

--- a/e2e/tests/hooks/framework.go
+++ b/e2e/tests/hooks/framework.go
@@ -1,0 +1,8 @@
+package hooks
+
+import "github.com/onsi/ginkgo"
+
+// DevSpaceDescribe annotates the test with the label.
+func DevSpaceDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[hooks] "+text, body)
+}

--- a/e2e/tests/hooks/hooks.go
+++ b/e2e/tests/hooks/hooks.go
@@ -1,0 +1,155 @@
+package hooks
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"github.com/loft-sh/devspace/cmd"
+	"github.com/loft-sh/devspace/cmd/flags"
+	"github.com/loft-sh/devspace/e2e/framework"
+	"github.com/loft-sh/devspace/e2e/kube"
+	"github.com/loft-sh/devspace/pkg/util/factory"
+	"github.com/onsi/ginkgo"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var _ = DevSpaceDescribe("hooks", func() {
+	initialDir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	// create a new factory
+	var (
+		f          factory.Factory
+		kubeClient *kube.KubeHelper
+	)
+
+	ginkgo.BeforeEach(func() {
+		f = framework.NewDefaultFactory()
+
+		kubeClient, err = kube.NewKubeHelper()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("should execute hook once", func() {
+		tempDir, err := framework.CopyToTempDir("tests/hooks/testdata/once")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		ns, err := kubeClient.CreateNamespace("hooks")
+		framework.ExpectNoError(err)
+		defer func() {
+			err := kubeClient.DeleteNamespace(ns)
+			framework.ExpectNoError(err)
+		}()
+
+		// waitGroup for both commands
+		waitGroup := sync.WaitGroup{}
+
+		// create first dev command
+		interrupt1, stop1 := framework.InterruptChan()
+		defer stop1()
+		devCmd1 := &cmd.DevCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				NoWarn:    true,
+				Namespace: ns,
+			},
+			Portforwarding: true,
+			Sync:           true,
+			Interrupt:      interrupt1,
+		}
+
+		// start the command
+		waitGroup.Add(1)
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			defer waitGroup.Done()
+			err = devCmd1.Run(f, nil)
+			framework.ExpectNoError(err)
+		}()
+
+		// Read the 'once' hook output
+		onceOutput1 := ""
+		err = wait.PollImmediate(time.Second, time.Minute*2, func() (done bool, err error) {
+			onceOutput1, err = kubeClient.ExecByImageSelector("node", ns, []string{"cat", "/app/once.out"})
+			if err != nil {
+				return false, nil
+			}
+
+			return onceOutput1 != "", nil
+		})
+		framework.ExpectNoError(err)
+
+		// Read the 'each' hook output
+		eachOutput1 := ""
+		err = wait.PollImmediate(time.Second, time.Minute*2, func() (done bool, err error) {
+			eachOutput1, err = kubeClient.ExecByImageSelector("node", ns, []string{"cat", "/app/each.out"})
+			if err != nil {
+				return false, nil
+			}
+
+			return eachOutput1 != "", nil
+		})
+		framework.ExpectNoError(err)
+
+		// stop first command
+		stop1()
+
+		// create second dev command
+		interrupt2, stop2 := framework.InterruptChan()
+		defer stop2()
+		devCmd2 := &cmd.DevCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				NoWarn:    true,
+				Namespace: ns,
+			},
+			Portforwarding: true,
+			Sync:           true,
+			Interrupt:      interrupt2,
+		}
+
+		// start the command
+		waitGroup.Add(1)
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			defer waitGroup.Done()
+			err = devCmd2.Run(f, nil)
+			framework.ExpectNoError(err)
+		}()
+
+		// Wait for 'each' hook output to change
+		eachOutput2 := ""
+		err = wait.PollImmediate(time.Second, time.Minute*2, func() (done bool, err error) {
+			eachOutput2, err = kubeClient.ExecByImageSelector("node", ns, []string{"cat", "/app/each.out"})
+			if err != nil {
+				return false, nil
+			}
+
+			return eachOutput2 != eachOutput1, nil
+		})
+		framework.ExpectNoError(err)
+
+		// Read the 'once' hook output again
+		onceOutput2 := ""
+		err = wait.PollImmediate(time.Second, time.Minute*2, func() (done bool, err error) {
+			onceOutput2, err = kubeClient.ExecByImageSelector("node", ns, []string{"cat", "/app/once.out"})
+			if err != nil {
+				return false, nil
+			}
+
+			return onceOutput2 != "", nil
+		})
+		framework.ExpectNoError(err)
+
+		// stop second command
+		stop2()
+
+		// Verify that the 'once' hook did not run again
+		framework.ExpectEqual(onceOutput1, onceOutput2)
+
+		// wait for the command to finish
+		waitGroup.Wait()
+	})
+})

--- a/e2e/tests/hooks/testdata/once/devspace.yaml
+++ b/e2e/tests/hooks/testdata/once/devspace.yaml
@@ -1,0 +1,28 @@
+version: v1beta11
+vars:
+  - name: IMAGE
+    value: node:13.14-alpine
+deployments:
+  - name: test
+    helm:
+      componentChart: true
+      values:
+        containers:
+          - image: ${IMAGE}
+            command: ["sleep"]
+            args: ["999999999999"]
+hooks:
+  - command: |
+      mkdir -p /app
+      echo -n $RANDOM > /app/once.out
+    container:
+      imageSelector: ${IMAGE}
+      once: true
+    events: ["after:deploy"]
+  - command: |
+      mkdir -p /app
+      echo -n $RANDOM > /app/each.out
+    container:
+      imageSelector: ${IMAGE}
+    events: ["after:deploy"]
+  

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1032,6 +1032,7 @@ type HookContainer struct {
 
 	Wait    *bool `yaml:"wait,omitempty" json:"wait,omitempty"`
 	Timeout int64 `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	Once    *bool `yaml:"once,omitempty" json:"once,omitempty"`
 }
 
 // HookWhenConfig defines when the hook should be executed

--- a/pkg/devspace/hook/download.go
+++ b/pkg/devspace/hook/download.go
@@ -17,6 +17,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
+	"github.com/mgutz/ansi"
 	"github.com/pkg/errors"
 	k8sv1 "k8s.io/api/core/v1"
 )
@@ -37,6 +38,7 @@ func (r *remoteDownloadHook) ExecuteRemotely(hook *latest.HookConfig, podContain
 		localPath = hook.Download.LocalPath
 	}
 
+	log.Infof("Execute hook '%s' in container '%s/%s/%s'", ansi.Color(hookName(hook), "white+b"), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name)
 	log.Infof("Copy container '%s' -> local '%s'", containerPath, localPath)
 	// Make sure the target folder exists
 	destDir := path.Dir(localPath)

--- a/pkg/devspace/hook/logs.go
+++ b/pkg/devspace/hook/logs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
+	"github.com/mgutz/ansi"
 )
 
 func NewLogsHook(writer io.Writer) RemoteHook {
@@ -23,6 +24,7 @@ type remoteLogsHook struct {
 }
 
 func (r *remoteLogsHook) ExecuteRemotely(hook *latest.HookConfig, podContainer *selector.SelectedPodContainer, client kubectl.Client, config config.Config, dependencies []types.Dependency, log logpkg.Logger) error {
+	log.Infof("Execute hook '%s' in container '%s/%s/%s'", ansi.Color(hookName(hook), "white+b"), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name)
 	reader, err := client.Logs(context.TODO(), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name, false, hook.Logs.TailLines, true)
 	if err != nil {
 		return err

--- a/pkg/devspace/hook/remote_command.go
+++ b/pkg/devspace/hook/remote_command.go
@@ -1,15 +1,21 @@
 package hook
 
 import (
+	"bytes"
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
+	"github.com/loft-sh/devspace/pkg/util/hash"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
+	"github.com/mgutz/ansi"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/util/exec"
 )
 
 func NewRemoteCommandHook(stdout io.Writer, stderr io.Writer) RemoteHook {
@@ -37,6 +43,21 @@ func (r *remoteCommandHook) ExecuteRemotely(hook *latest.HookConfig, podContaine
 		cmd = append(cmd, hookArgs...)
 	}
 
+	once := hook.Container.Once != nil && *hook.Container.Once
+	if once {
+		// check whether hook has previously executed
+		hookExecuted, err := hasHookExecuted(hookCommand, hookArgs, podContainer, client)
+		if err != nil {
+			return errors.Errorf("error checking whether hook has executed '%s/%s/%s': %v", podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name, err)
+		}
+
+		if hookExecuted {
+			log.Infof("Skip hook '%s' because it is configured to run once", ansi.Color(hookName(hook), "white+b"))
+			return nil
+		}
+	}
+
+	log.Infof("Execute hook '%s' in container '%s/%s/%s'", ansi.Color(hookName(hook), "white+b"), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name)
 	err = client.ExecStream(&kubectl.ExecStreamOptions{
 		Pod:       podContainer.Pod,
 		Container: podContainer.Container.Name,
@@ -46,6 +67,61 @@ func (r *remoteCommandHook) ExecuteRemotely(hook *latest.HookConfig, podContaine
 	})
 	if err != nil {
 		return errors.Errorf("error in container '%s/%s/%s': %v", podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name, err)
+	}
+
+	if once {
+		// record hook execution
+		err := recordHookExecuted(hookCommand, hookArgs, podContainer, client)
+		if err != nil {
+			return errors.Errorf("error recording hook execution %s in container '%s/%s/%s': %v", ansi.Color(hookName(hook), "white+b"), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func commandHash(command string, args []string) string {
+	return hash.String(fmt.Sprintf("%s %s", command, strings.Join(args, " ")))
+}
+
+func hasHookExecuted(command string, args []string, podContainer *selector.SelectedPodContainer, client kubectl.Client) (bool, error) {
+	cmdHash := commandHash(command, args)
+	cmd := []string{"test", "-e", fmt.Sprintf(`/tmp/hook-%s`, cmdHash)}
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	err := client.ExecStream(&kubectl.ExecStreamOptions{
+		Pod:       podContainer.Pod,
+		Container: podContainer.Container.Name,
+		Command:   cmd,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err != nil {
+		if errors.As(err, &exec.CodeExitError{}) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func recordHookExecuted(command string, args []string, podContainer *selector.SelectedPodContainer, client kubectl.Client) error {
+	cmdHash := commandHash(command, args)
+	cmd := []string{"touch", fmt.Sprintf(`/tmp/hook-%s`, cmdHash)}
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	err := client.ExecStream(&kubectl.ExecStreamOptions{
+		Pod:       podContainer.Pod,
+		Container: podContainer.Container.Name,
+		Command:   cmd,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/devspace/hook/remote_hook.go
+++ b/pkg/devspace/hook/remote_hook.go
@@ -118,7 +118,6 @@ func (r *remoteHook) execute(hook *latest.HookConfig, imageSelector []imageselec
 	}
 
 	// execute the hook in the container
-	log.Infof("Execute hook '%s' in container '%s/%s/%s'", ansi.Color(hookName(hook), "white+b"), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name)
 	err = r.Hook.ExecuteRemotely(hook, podContainer, client, config, dependencies, log)
 	if err != nil {
 		return false, err

--- a/pkg/devspace/hook/upload.go
+++ b/pkg/devspace/hook/upload.go
@@ -15,6 +15,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
+	"github.com/mgutz/ansi"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 )
@@ -35,6 +36,7 @@ func (r *remoteUploadHook) ExecuteRemotely(hook *latest.HookConfig, podContainer
 		localPath = hook.Upload.LocalPath
 	}
 
+	log.Infof("Execute hook '%s' in container '%s/%s/%s'", ansi.Color(hookName(hook), "white+b"), podContainer.Pod.Namespace, podContainer.Pod.Name, podContainer.Container.Name)
 	log.Infof("Copy local '%s' -> container '%s'", localPath, containerPath)
 	// Make sure the target folder exists
 	destDir := path.Dir(containerPath)


### PR DESCRIPTION
### Changes
- Add new option: `hooks[*].container.once` that will configure remote container command hooks to run only once per deployment