### PR TITLE
refactor: set old pod as hostname & new e2e test

### DIFF
--- a/e2e/tests/replacepods/replacepods.go
+++ b/e2e/tests/replacepods/replacepods.go
@@ -39,6 +39,114 @@ var _ = DevSpaceDescribe("replacepods", func() {
 		framework.ExpectNoError(err)
 	})
 
+	ginkgo.It("should replace statefulset pod", func() {
+		tempDir, err := framework.CopyToTempDir("tests/replacepods/testdata/statefulset")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		ns, err := kubeClient.CreateNamespace("replacepods")
+		framework.ExpectNoError(err)
+		defer framework.ExpectDeleteNamespace(kubeClient, ns)
+
+		// create a new dev command
+		devCmd := &cmd.DevCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				NoWarn:    true,
+				Namespace: ns,
+			},
+			Portforwarding: true,
+			Sync:           true,
+		}
+		err = devCmd.Run(f, []string{"sh", "-c", "exit"})
+		framework.ExpectNoError(err)
+
+		// check if replica set exists & pod got replaced correctly
+		list, err := kubeClient.Client().KubeClient().AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: podreplace.ReplicaSetLabel + "=true"})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(list.Items), 1)
+
+		// wait until a pod has started
+		var pods *corev1.PodList
+		err = wait.Poll(time.Second, time.Minute*3, func() (done bool, err error) {
+			pods, err = kubeClient.RawClient().CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.ReplacedLabel})
+			if err != nil {
+				return false, err
+			}
+
+			return len(pods.Items) == 1, nil
+		})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(pods.Items[0].Spec.Containers[0].Image, "ubuntu:18.04")
+
+		// make sure hostname is correct
+		out, err := kubeClient.ExecByContainer("app=nginx", "nginx", ns, []string{"sh", "-c", "echo -n $HOSTNAME"})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(out, "test-statefulset-0")
+
+		// now make a change to the config
+		fileContents, err := ioutil.ReadFile("devspace.yaml")
+		framework.ExpectNoError(err)
+
+		newString := strings.Replace(string(fileContents), "ubuntu:18.04", "alpine:3.14", -1)
+		err = ioutil.WriteFile("devspace.yaml", []byte(newString), 0666)
+		framework.ExpectNoError(err)
+
+		// rerun
+		devCmd = &cmd.DevCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				NoWarn:    true,
+				Namespace: ns,
+			},
+			Portforwarding: true,
+			Sync:           true,
+		}
+		err = devCmd.Run(f, []string{"sh", "-c", "exit"})
+		framework.ExpectNoError(err)
+
+		// check if replica set exists & pod got replaced correctly
+		list, err = kubeClient.Client().KubeClient().AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: podreplace.ReplicaSetLabel + "=true"})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(list.Items), 1)
+
+		// wait until a pod has started
+		err = wait.Poll(time.Second, time.Minute*3, func() (done bool, err error) {
+			pods, err = kubeClient.RawClient().CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.ReplacedLabel})
+			if err != nil {
+				return false, err
+			}
+
+			return len(pods.Items) == 1, nil
+		})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(pods.Items[0].Spec.Containers[0].Image, "alpine:3.14")
+
+		// now purge the deployment and make sure the replica set is deleted as well
+		purgeCmd := &cmd.PurgeCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				NoWarn:    true,
+				Namespace: ns,
+			},
+		}
+		err = purgeCmd.Run(f)
+		framework.ExpectNoError(err)
+
+		// wait until all pods are killed
+		err = wait.Poll(time.Second, time.Minute*3, func() (done bool, err error) {
+			pods, err = kubeClient.RawClient().CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.ReplacedLabel})
+			if err != nil {
+				return false, err
+			}
+
+			return len(pods.Items) == 0, nil
+		})
+		framework.ExpectNoError(err)
+
+		// make sure no replaced replica set exists anymore
+		list, err = kubeClient.Client().KubeClient().AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: podreplace.ReplicaSetLabel + "=true"})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(len(list.Items), 0)
+	})
+
 	ginkgo.It("should replace deployment pod", func() {
 		tempDir, err := framework.CopyToTempDir("tests/replacepods/testdata/deployment")
 		framework.ExpectNoError(err)

--- a/e2e/tests/replacepods/testdata/statefulset/devspace.yaml
+++ b/e2e/tests/replacepods/testdata/statefulset/devspace.yaml
@@ -1,0 +1,25 @@
+version: v1beta11
+vars:
+  - name: IMAGE
+    value: john/devbackend
+deployments:
+  - name: test
+    kubectl:
+      manifests:
+        - statefulset.yaml
+dev:
+  replacePods:
+    - imageSelector: ${IMAGE}
+      replaceImage: ubuntu:18.04
+      patches:
+        - op: add
+          path: spec.containers[0].command
+          value: ["sleep"]
+        - op: add
+          path: spec.containers[0].args
+          value: ["9999999999"]
+        - op: add
+          path: spec.containers[0].workingDir
+          value: "/workdir"
+  terminal:
+    imageSelector: ${IMAGE}

--- a/e2e/tests/replacepods/testdata/statefulset/statefulset.yaml
+++ b/e2e/tests/replacepods/testdata/statefulset/statefulset.yaml
@@ -1,0 +1,38 @@
+# https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  clusterIP: None
+  ports:
+    - name: web
+      port: 80
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx  # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  template:
+    metadata:
+      labels:
+        app: nginx  # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - image: john/devbackend
+          name: nginx
+          ports:
+            - containerPort: 80
+              name: web

--- a/pkg/devspace/services/podreplace/podreplace.go
+++ b/pkg/devspace/services/podreplace/podreplace.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	yaml2 "github.com/ghodss/yaml"
@@ -471,6 +472,9 @@ func replace(ctx context.Context, client kubectl.Client, pod *selector.SelectedP
 	}
 
 	copiedPod := pod.Pod.DeepCopyObject().(*corev1.Pod)
+	if _, ok := parent.(*appsv1.StatefulSet); ok {
+		copiedPod.Spec.Hostname = strings.Replace(pod.Pod.Name, ".", "-", -1)
+	}
 
 	// replace the image name
 	if replacePod.ReplaceImage != "" {


### PR DESCRIPTION
### Changes
- DevSpace will now set the statefulsets pod name as hostname in the replaced pods