### PR TITLE
feat: resources option for pre-populate init container

### DIFF
--- a/docs/pages/configuration/development/replace-pods.mdx
+++ b/docs/pages/configuration/development/replace-pods.mdx
@@ -261,6 +261,17 @@ dev:
 - DevSpace would create a new persistent volume claim for the pod if the pod was not yet replaced
 - DevSpace would replace the pod with a pod which has a volume mount for the path `/app` that references the created persistent volume claim
 
+#### Options
+
+You can configure the following options in a persistent path:
+
+- `path`: the container path that should get persisted
+- `volumePath`: optional path on the persistent volume to mount
+- `containerName`: optional container name in the replaced pod to persist the path
+- `readOnly`: if the path should get mounted read only
+- `skipPopulate`: if true, devspace will not try to pre-populate the path
+- `initContainer.resources`: resources of the pre-populating init container
+
 ### `persistenceOptions`
 
 `persistenceOptions` is an object that defines additional options for `persistPaths`. You can configure the following options:

--- a/docs/pages/configuration/reference.mdx
+++ b/docs/pages/configuration/reference.mdx
@@ -343,6 +343,9 @@ replacePods:                              # struct[] | Which pods should be repl
     volumePath: /my-volume/app            # string   | Optional path on the persistent volume to mount
     containerName: ""                     # string   | Optional container name in the replaced pod to persist the path
     readOnly: false                       # bool     | If the path should get mounted read only
+    skipPopulate: false                   # bool     | If true, devspace will not try to pre-populate the path
+    initContainer:                        # struct   | Additional options for the pre-populating init container 
+      resources: {}                       # struct   | Resources of the pre-populating init container
   persistenceOptions:                     # struct   | Additional options for persistPaths
     name: ""                              # string   | Optional name of the pvc to reuse / create
     size: "10Gi"                          # string   | Size of the pvc to create 

--- a/pkg/devspace/build/builder/buildkit/buildkit.go
+++ b/pkg/devspace/build/builder/buildkit/buildkit.go
@@ -66,7 +66,7 @@ func (b *Builder) ShouldRebuild(cache *generated.CacheConfig, forceRebuild bool,
 
 			found, err := b.helper.IsImageAvailableLocally(cache, dockerClient)
 			if !found && err == nil {
-				log.Debugf("Rebuild image %s because it was not found in local docker daemon", cache.Images[b.helper.ImageConfigName].ImageName)
+				log.Infof("Rebuild image %s because it was not found in local docker daemon", cache.Images[b.helper.ImageConfigName].ImageName)
 				return true, nil
 			}
 		}

--- a/pkg/devspace/build/builder/docker/docker.go
+++ b/pkg/devspace/build/builder/docker/docker.go
@@ -78,7 +78,7 @@ func (b *Builder) ShouldRebuild(cache *generated.CacheConfig, forceRebuild bool,
 		if b.skipPushOnLocalKubernetes && b.helper.KubeClient != nil && b.helper.KubeClient.IsLocalKubernetes() {
 			found, err := b.helper.IsImageAvailableLocally(cache, b.client)
 			if !found && err == nil {
-				log.Debugf("Rebuild image %s because it was not found in local docker daemon", cache.Images[b.helper.ImageConfigName].ImageName)
+				log.Infof("Rebuild image %s because it was not found in local docker daemon", cache.Images[b.helper.ImageConfigName].ImageName)
 				return true, nil
 			}
 		}

--- a/pkg/devspace/build/builder/helper/helper.go
+++ b/pkg/devspace/build/builder/helper/helper.go
@@ -114,7 +114,7 @@ func (b *BuildHelper) ShouldRebuild(cache *generated.CacheConfig, forceRebuild b
 
 	// if rebuild strategy is always, we return here
 	if b.ImageConf.RebuildStrategy == latest.RebuildStrategyAlways {
-		log.Debugf("Rebuild image %s because strategy is always rebuild", imageCache.ImageName)
+		log.Infof("Rebuild image %s because strategy is always rebuild", imageCache.ImageName)
 		return true, nil
 	}
 
@@ -155,20 +155,20 @@ func (b *BuildHelper) ShouldRebuild(cache *generated.CacheConfig, forceRebuild b
 	// only rebuild Docker image when Dockerfile or context has changed since latest build
 	mustRebuild := imageCache.Tag == "" || imageCache.DockerfileHash != dockerfileHash || imageCache.ImageConfigHash != imageConfigHash || imageCache.EntrypointHash != entrypointHash
 	if imageCache.Tag == "" {
-		log.Debugf("Rebuild image %s because tag is missing", imageCache.ImageName)
+		log.Infof("Rebuild image %s because tag is missing", imageCache.ImageName)
 	} else if imageCache.DockerfileHash != dockerfileHash {
-		log.Debugf("Rebuild image %s because dockerfile has changed", imageCache.ImageName)
+		log.Infof("Rebuild image %s because dockerfile has changed", imageCache.ImageName)
 	} else if imageCache.ImageConfigHash != imageConfigHash {
-		log.Debugf("Rebuild image %s because image config has changed", imageCache.ImageName)
+		log.Infof("Rebuild image %s because image config has changed", imageCache.ImageName)
 	} else if imageCache.EntrypointHash != entrypointHash {
-		log.Debugf("Rebuild image %s because entrypoint has changed", imageCache.ImageName)
+		log.Infof("Rebuild image %s because entrypoint has changed", imageCache.ImageName)
 	}
 
 	// Okay this check verifies if the previous deploy context was local kubernetes context where we didn't push the image and now have a kubernetes context where we probably push
 	// or use another docker client (e.g. minikube <-> docker-desktop)
-	if b.KubeClient != nil && cache.LastContext != nil && cache.LastContext.Context != b.KubeClient.CurrentContext() && kubectl.IsLocalKubernetes(cache.LastContext.Context) {
+	if !mustRebuild && b.KubeClient != nil && cache.LastContext != nil && cache.LastContext.Context != b.KubeClient.CurrentContext() && kubectl.IsLocalKubernetes(cache.LastContext.Context) {
 		mustRebuild = true
-		log.Debugf("Rebuild image %s because previous build was local kubernetes", imageCache.ImageName)
+		log.Infof("Rebuild image %s because previous build was local kubernetes", imageCache.ImageName)
 	}
 
 	// Check if should consider context path changes for rebuilding
@@ -191,7 +191,7 @@ func (b *BuildHelper) ShouldRebuild(cache *generated.CacheConfig, forceRebuild b
 		}
 
 		if !mustRebuild && imageCache.ContextHash != contextHash {
-			log.Debugf("Rebuild image %s because context has changed", imageCache.ImageName)
+			log.Infof("Rebuild image %s because build context has changed", imageCache.ImageName)
 		}
 		mustRebuild = mustRebuild || imageCache.ContextHash != contextHash
 

--- a/pkg/devspace/build/builder/kaniko/build_pod.go
+++ b/pkg/devspace/build/builder/kaniko/build_pod.go
@@ -2,6 +2,7 @@ package kaniko
 
 import (
 	"context"
+	"github.com/loft-sh/devspace/pkg/devspace/build/builder/kaniko/util"
 	"path/filepath"
 
 	"github.com/docker/distribution/reference"
@@ -337,11 +338,11 @@ func (b *Builder) getBuildPod(buildID string, devspacePID string, options *types
 		}
 	} else {
 		// convert resources
-		limits, err := ConvertMap(kanikoOptions.Resources.Limits)
+		limits, err := util.ConvertMap(kanikoOptions.Resources.Limits)
 		if err != nil {
 			return nil, errors.Wrap(err, "limits")
 		}
-		requests, err := ConvertMap(kanikoOptions.Resources.Requests)
+		requests, err := util.ConvertMap(kanikoOptions.Resources.Requests)
 		if err != nil {
 			return nil, errors.Wrap(err, "requests")
 		}
@@ -358,24 +359,6 @@ func (b *Builder) getBuildPod(buildID string, devspacePID string, options *types
 
 	// return the build pod
 	return pod, nil
-}
-
-func ConvertMap(m map[string]string) (map[k8sv1.ResourceName]resource.Quantity, error) {
-	if m == nil {
-		return nil, nil
-	}
-
-	retMap := map[k8sv1.ResourceName]resource.Quantity{}
-	for k, v := range m {
-		pv, err := resource.ParseQuantity(v)
-		if err != nil {
-			return nil, errors.Wrapf(err, "parse kaniko pod resource quantity %s", k)
-		}
-
-		retMap[k8sv1.ResourceName(k)] = pv
-	}
-
-	return retMap, nil
 }
 
 // Determine available resources (This is only necessary in the devspace cloud)

--- a/pkg/devspace/build/builder/kaniko/util/util.go
+++ b/pkg/devspace/build/builder/kaniko/util/util.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"github.com/pkg/errors"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func ConvertMap(m map[string]string) (map[k8sv1.ResourceName]resource.Quantity, error) {
+	if m == nil {
+		return nil, nil
+	}
+
+	retMap := map[k8sv1.ResourceName]resource.Quantity{}
+	for k, v := range m {
+		pv, err := resource.ParseQuantity(v)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse kaniko pod resource quantity %s", k)
+		}
+
+		retMap[k8sv1.ResourceName(k)] = pv
+	}
+
+	return retMap, nil
+}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -312,14 +312,14 @@ type KanikoConfig struct {
 	AdditionalMounts []KanikoAdditionalMount `yaml:"additionalMounts,omitempty" json:"additionalMounts,omitempty"`
 
 	// the resources that should be set on the kaniko pod
-	Resources *KanikoPodResources `yaml:"resources,omitempty" json:"resources,omitempty"`
+	Resources *PodResources `yaml:"resources,omitempty" json:"resources,omitempty"`
 
 	// other build options that will be passed to the kaniko pod
 	Options *BuildOptions `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
-// KanikoPodResources describes the resources section of the started kaniko pod
-type KanikoPodResources struct {
+// PodResources describes the resources section of the started kaniko pod
+type PodResources struct {
 	// The requests part of the resources
 	Requests map[string]string `yaml:"requests,omitempty" json:"requests,omitempty"`
 
@@ -724,6 +724,12 @@ type PersistentPath struct {
 	VolumePath    string `yaml:"volumePath,omitempty" json:"volumePath,omitempty"`
 	ReadOnly      bool   `yaml:"readOnly,omitempty" json:"readOnly,omitempty"`
 	SkipPopulate  bool   `yaml:"skipPopulate,omitempty" json:"skipPopulate,omitempty"`
+
+	InitContainer *PersistentPathInitContainer `yaml:"initContainer,omitempty" json:"initContainer,omitempty"`
+}
+
+type PersistentPathInitContainer struct {
+	Resources *PodResources `yaml:"resources,omitempty" json:"resources,omitempty"`
 }
 
 // PortForwardingConfig defines the ports for a port forwarding to a DevSpace


### PR DESCRIPTION
### Changes
- New option `dev.replacePods.persistPaths.initConainter.resources` to configure resources for the pre-populating init container (#1775)
- DevSpace will now print by default why it is rebuilding an image