### PR TITLE
fix: log dependency name instead of id

### DIFF
--- a/pkg/devspace/dependency/dependency.go
+++ b/pkg/devspace/dependency/dependency.go
@@ -535,7 +535,7 @@ func (d *Dependency) Purge(log log.Logger) error {
 	// Purge the deployments
 	err = d.deployController.Purge(nil, log)
 	if err != nil {
-		log.Errorf("Error purging dependency %s: %v", d.id, err)
+		log.Errorf("Error purging dependency %s: %v", d.Name(), err)
 	}
 
 	if d.generatedSaver != nil && d.localConfig != nil && d.localConfig.Generated() != nil {

--- a/pkg/devspace/dependency/graph.go
+++ b/pkg/devspace/dependency/graph.go
@@ -71,7 +71,7 @@ func (g *graph) insertNodeAt(parentID string, id string, data interface{}) (*nod
 func (g *graph) removeNode(id string) error {
 	if node, ok := g.Nodes[id]; ok {
 		if len(node.childs) > 0 {
-			return errors.Errorf("Cannot remove %s from graph because it has still children", id)
+			return errors.Errorf("Cannot remove %s from graph because it has still children", getNameOrID(node))
 		}
 
 		// Remove child from parents
@@ -111,9 +111,10 @@ type cyclicError struct {
 
 // Error implements error interface
 func (c *cyclicError) Error() string {
-	cycle := []string{c.path[len(c.path)-1].ID}
+	cycle := []string{getNameOrID(c.path[len(c.path)-1])}
+
 	for _, node := range c.path {
-		cycle = append(cycle, node.ID)
+		cycle = append(cycle, getNameOrID(node))
 	}
 
 	return fmt.Sprintf("Cyclic dependency found: \n%s", strings.Join(cycle, "\n"))
@@ -206,4 +207,17 @@ func findFirstPathRecursive(u *node, d *node, isVisited map[string]bool, localPa
 	// Mark the current node
 	delete(isVisited, u.ID)
 	return false
+}
+
+func getNameOrID(n *node) string {
+	dep, ok := n.Data.(*Dependency)
+
+	if ok {
+		depName := dep.Name()
+		if depName != "" {
+			return depName
+		}
+	}
+
+	return n.ID
 }

--- a/pkg/devspace/dependency/graph_test.go
+++ b/pkg/devspace/dependency/graph_test.go
@@ -2,6 +2,8 @@ package dependency
 
 import (
 	"testing"
+
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 )
 
 func TestGraph(t *testing.T) {
@@ -23,23 +25,35 @@ func TestGraph(t *testing.T) {
 
 	_, _ = testGraph.insertNodeAt(root.ID, rootChild1.ID, nil)
 	_, _ = testGraph.insertNodeAt(root.ID, rootChild2.ID, nil)
-	_, _ = testGraph.insertNodeAt(root.ID, rootChild3.ID, nil)
+	_, _ = testGraph.insertNodeAt(root.ID, rootChild3.ID, &Dependency{
+		dependencyConfig: &latest.DependencyConfig{
+			Name: "cyclic parent",
+		},
+	})
 
 	_, _ = testGraph.insertNodeAt(rootChild2.ID, rootChild2Child1.ID, nil)
-	_, _ = testGraph.insertNodeAt(rootChild2Child1.ID, rootChild2Child1Child1.ID, nil)
+	_, _ = testGraph.insertNodeAt(rootChild2Child1.ID, rootChild2Child1Child1.ID, &Dependency{
+		dependencyConfig: &latest.DependencyConfig{
+			Name: "cyclic child",
+		},
+	})
 	_, _ = testGraph.insertNodeAt(rootChild3.ID, rootChild2.ID, nil)
 
 	// Cyclic graph error
-	_, err = testGraph.insertNodeAt(rootChild2Child1Child1.ID, rootChild3.ID, nil)
+	_, err = testGraph.insertNodeAt(rootChild2Child1Child1.ID, rootChild3.ID, &Dependency{
+		dependencyConfig: &latest.DependencyConfig{
+			Name: "cyclic child",
+		},
+	})
 	if err == nil {
 		t.Fatal("Cyclic error expected")
 	} else {
 		errMsg := `Cyclic dependency found: 
-rootChild2Child1Child1
-rootChild3
+cyclic child
+cyclic parent
 rootChild2
 rootChild2Child1
-rootChild2Child1Child1`
+cyclic child`
 
 		if err.Error() != errMsg {
 			t.Fatalf("Expected %s, got %s", errMsg, err.Error())

--- a/pkg/devspace/dependency/util/util.go
+++ b/pkg/devspace/dependency/util/util.go
@@ -67,7 +67,7 @@ func DownloadDependency(ID, basePath string, source *latest.SourceConfig, update
 				return "", errors.Wrap(err, "clone repository")
 			}
 
-			log.Donef("Pulled %s", ID)
+			log.Donef("Pulled %s", gitPath)
 		}
 	} else if source.Path != "" {
 		if isURL(source.Path) {


### PR DESCRIPTION
### Changes
- Log dependency names instead of IDs