### PR TITLE
build: test cgo build for darwin/arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v') == true
     needs: [ release-ui ]
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Set up Go
         uses: actions/setup-go@v1

--- a/hack/build-all.bash
+++ b/hack/build-all.bash
@@ -84,10 +84,19 @@ for OS in ${DEVSPACE_BUILD_PLATFORMS[@]}; do
         echo "Building for ${OS}/${ARCH} not supported."
         continue
     fi
-
+    
     echo "Building for ${OS}/${ARCH}"
-    GOARCH=${ARCH} GOOS=${OS} ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
-      -o "${DEVSPACE_ROOT}/release/${NAME}" .
+    
+    # build darwin with CGO_ENABLED=1
+    if [[ "${OS}" == "darwin" ]]; then
+      CGO_ENABLED=1
+    else
+      CGO_ENABLED=0 
+    fi
+    
+    # build the DevSpace binary
+    CGO_ENABLED=${CGO_ENABLED} GOARCH=${ARCH} GOOS=${OS} ${GO_BUILD_CMD} -ldflags "${GO_BUILD_LDFLAGS}"\
+                  -o "${DEVSPACE_ROOT}/release/${NAME}" .
     shasum -a 256 "${DEVSPACE_ROOT}/release/${NAME}" > "${DEVSPACE_ROOT}/release/${NAME}".sha256
   done
 done


### PR DESCRIPTION
### Changes
- use `CGO_ENABLED=1` for `darwin` builds to prevent `too many files open` issue