### PR TITLE
feat: add run commands to help usage

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -164,6 +164,43 @@ func BuildRoot(f factory.Factory, excludePlugins bool) *cobra.Command {
 	persistentFlags := rootCmd.PersistentFlags()
 	globalFlags = flags.SetGlobalFlags(persistentFlags)
 
+	rootCmd.SetUsageTemplate(`Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+  
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+  
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+  
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+  
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+{{- if (and .HasAvailableSubCommands) -}}
+{{- range .Commands -}}
+{{- if (and .HasSubCommands (eq .Name "run"))}}
+
+Additional run commands:
+{{- range .Commands}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`)
+
 	// Add sub commands
 	rootCmd.AddCommand(add.NewAddCmd(f, globalFlags, plugins))
 	rootCmd.AddCommand(cleanup.NewCleanupCmd(f, globalFlags, plugins))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -104,10 +104,11 @@ devspace --dependency my-dependency run any-command --any-command-flag
 			description = "Runs " + command.Command
 		}
 		runCmd.AddCommand(&cobra.Command{
-			Use:   command.Name,
-			Short: description,
-			Long:  description,
-			Args:  cobra.ArbitraryArgs,
+			Use:                command.Name,
+			Short:              description,
+			Long:               description,
+			Args:               cobra.ArbitraryArgs,
+			DisableFlagParsing: true,
 			RunE: func(cobraCmd *cobra.Command, args []string) error {
 				return cobraCmd.Parent().RunE(cobraCmd, args)
 			},


### PR DESCRIPTION
### Changes
- Adds `devspace.yaml` configured commands to cobra command configuration.

### Details
`devspace --help` displays the custom commands under `Additional run commands:` using a custom template
```
DevSpace accelerates developing, deploying and debugging applications with Docker and Kubernetes. Get started by running the init command in one of your projects:

                devspace init

Usage:
  devspace [command]
  
Available Commands:
  add         Convenience command: adds something to devspace.yaml
  analyze     Analyzes a kubernetes namespace and checks for potential problems
  attach      Attaches to a container
  build       Builds all defined images and pushes them
  cleanup     Cleans up resources
  completion  Output shell completion for the given shell (bash or zsh)
  deploy      Deploy the project
  dev         Starts the development mode
  enter       Open a shell to a container
  help        Help about any command
  init        Initializes DevSpace in the current folder
  list        Lists configuration
  logs        Prints the logs of a pod and attaches to it
  open        Opens the space in the browser
  print       Print displays the configuration
  purge       Delete deployed resources
  remove      Changes devspace configuration
  render      Render builds all defined images and shows the yamls that would be deployed
  reset       Resets an cluster token
  restart     Restarts containers where the sync restart helper is injected
  restore     Restore configuration
  run         Run executes a predefined command
  save        Save configuration
  set         Make global configuration changes
  sync        Starts a bi-directional sync between the target container and the local path
  ui          Opens the localhost UI in the browser
  update      Updates the current config
  upgrade     Upgrade the DevSpace CLI to the newest version
  use         Use specific config
  
Flags:
      --config string                The devspace config file to use
      --debug                        Prints the stack trace if an error occurs
      --disable-profile-activation   If true will ignore all profile activations
  -h, --help                         help for devspace
      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
      --kube-context string          The kubernetes context to use
  -n, --namespace string             The kubernetes namespace to use
      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
  -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
      --profile-refresh              If true will pull and re-download profile parent sources
      --restore-vars                 If true will restore the variables from kubernetes before loading the config
      --save-vars                    If true will save the variables to kubernetes after loading the config
      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
  -s, --switch-context               DEPRECATED: Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")

Additional run commands:
  devspace run test1 Runs echo -n
  devspace run test2 Runs echo -n $@

Use "devspace [command] --help" for more information about a command.
```

`devspace run --help` displays the commands under `Available commands:` using using cobra's default behavior
```
#######################################################
##################### devspace run ####################
#######################################################
Run executes a predefined command from the devspace.yaml

Examples:
devspace run mycommand --myarg 123
devspace run mycommand2 1 2 3
devspace --dependency my-dependency run any-command --any-command-flag
#######################################################

Usage:
  devspace run [flags]
  devspace run [command]
  
Available Commands:
  test1       Runs echo -n
  test2       Runs echo -n $@
  
Flags:
      --dependency string   Run a command from a specific dependency
  -h, --help                help for run
  
Global Flags:
      --config string                The devspace config file to use
      --debug                        Prints the stack trace if an error occurs
      --disable-profile-activation   If true will ignore all profile activations
      --inactivity-timeout int       Minutes the current user is inactive (no mouse or keyboard interaction) until DevSpace will exit automatically. 0 to disable. Only supported on windows and mac operating systems (default 180)
      --kube-context string          The kubernetes context to use
  -n, --namespace string             The kubernetes namespace to use
      --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
  -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
      --profile-parent strings       One or more profiles that should be applied before the specified profile (e.g. devspace dev --profile-parent=base1 --profile-parent=base2 --profile=my-profile)
      --profile-refresh              If true will pull and re-download profile parent sources
      --restore-vars                 If true will restore the variables from kubernetes before loading the config
      --save-vars                    If true will save the variables to kubernetes after loading the config
      --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
  -s, --switch-context               DEPRECATED: Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
      --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
      --vars-secret string           The secret to restore/save the variables from/to, if --restore-vars or --save-vars is enabled (default "devspace-vars")

Use "devspace run [command] --help" for more information about a command.
```