### PR TITLE
fix: profiles should not activate on substring matches

### DIFF
--- a/docs/pages/configuration/profiles/activation.mdx
+++ b/docs/pages/configuration/profiles/activation.mdx
@@ -31,7 +31,7 @@ profiles:
     path: images.backend.image
     value: john/prodbackend
 ```
-The profile `production` would be activated when the environment variable `ENV` matches the regular expression `prod-\d+`. This can be useful for matching environment variables that have dynamic values.
+The profile `production` would be activated when the environment variable `ENV` matches the regular expression `prod-\d+`. This can be useful for matching environment variables that have dynamic values. Regular expressions will have start of string (`^`) and end of string (`$`) anchors added automatically to avoid unexpected substring matching. 
 
 #### Example: Matching All Environment Variables
 When multiple `env` name/expression pairs are specified in the same activation, all environment variables values must match the expression to activate the profile. For example, the `production` profile is activated when both environment variables match their expressions:

--- a/e2e/tests/config/config.go
+++ b/e2e/tests/config/config.go
@@ -288,6 +288,110 @@ var _ = DevSpaceDescribe("config", func() {
 		framework.ExpectEqual(latestConfig.Deployments[1].Name, "test2")
 	})
 
+	ginkgo.It("should auto activate profile using exact string matching environment variable", func() {
+		tempDir, err := framework.CopyToTempDir("tests/config/testdata/profile-activation")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		// run with non-matching vars
+		configBuffer := &bytes.Buffer{}
+		printCmd := &cmd.PrintCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				ConfigPath: "string-exact.yaml",
+			},
+			Out:      configBuffer,
+			SkipInfo: true,
+		}
+
+		os.Setenv("FOO", "test123")
+		err = printCmd.Run(f)
+		framework.ExpectNoError(err)
+		os.Unsetenv("FOO")
+
+		latestConfig := &latest.Config{}
+		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
+		framework.ExpectNoError(err)
+
+		// validate no profile was activated
+		framework.ExpectEqual(len(latestConfig.Deployments), 0)
+
+		// run with environment variable set.
+		configBuffer = &bytes.Buffer{}
+		printCmd = &cmd.PrintCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				ConfigPath: "string-exact.yaml",
+			},
+			Out:      configBuffer,
+			SkipInfo: true,
+		}
+
+		os.Setenv("FOO", "test")
+		err = printCmd.Run(f)
+		framework.ExpectNoError(err)
+		os.Unsetenv("FOO")
+
+		latestConfig = &latest.Config{}
+		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
+		framework.ExpectNoError(err)
+
+		// validate profile was activated
+		framework.ExpectEqual(len(latestConfig.Deployments), 2)
+		framework.ExpectEqual(latestConfig.Deployments[0].Name, "test")
+		framework.ExpectEqual(latestConfig.Deployments[1].Name, "test2")
+	})
+
+	ginkgo.It("should auto activate profile using exact regular expression matching environment variable", func() {
+		tempDir, err := framework.CopyToTempDir("tests/config/testdata/profile-activation")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		// run with non-matching vars
+		configBuffer := &bytes.Buffer{}
+		printCmd := &cmd.PrintCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				ConfigPath: "regexp-exact.yaml",
+			},
+			Out:      configBuffer,
+			SkipInfo: true,
+		}
+
+		os.Setenv("FOO", "some test here")
+		err = printCmd.Run(f)
+		framework.ExpectNoError(err)
+		os.Unsetenv("FOO")
+
+		latestConfig := &latest.Config{}
+		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
+		framework.ExpectNoError(err)
+
+		// validate no profile was activated
+		framework.ExpectEqual(len(latestConfig.Deployments), 0)
+
+		// run with environment variable set.
+		configBuffer = &bytes.Buffer{}
+		printCmd = &cmd.PrintCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				ConfigPath: "regexp-exact.yaml",
+			},
+			Out:      configBuffer,
+			SkipInfo: true,
+		}
+
+		os.Setenv("FOO", "test")
+		err = printCmd.Run(f)
+		framework.ExpectNoError(err)
+		os.Unsetenv("FOO")
+
+		latestConfig = &latest.Config{}
+		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
+		framework.ExpectNoError(err)
+
+		// validate profile was activated
+		framework.ExpectEqual(len(latestConfig.Deployments), 2)
+		framework.ExpectEqual(latestConfig.Deployments[0].Name, "test")
+		framework.ExpectEqual(latestConfig.Deployments[1].Name, "test2")
+	})
+
 	ginkgo.It("should auto activate profile using regular expression matching environment variable", func() {
 		tempDir, err := framework.CopyToTempDir("tests/config/testdata/profile-activation")
 		framework.ExpectNoError(err)
@@ -325,7 +429,59 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "truthy")
+		os.Setenv("FOO", "^the string begins with ^t and ends with $")
+		err = printCmd.Run(f)
+		framework.ExpectNoError(err)
+		os.Unsetenv("FOO")
+
+		latestConfig = &latest.Config{}
+		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
+		framework.ExpectNoError(err)
+
+		// validate profile was activated
+		framework.ExpectEqual(len(latestConfig.Deployments), 2)
+		framework.ExpectEqual(latestConfig.Deployments[0].Name, "test")
+		framework.ExpectEqual(latestConfig.Deployments[1].Name, "test2")
+	})
+
+	ginkgo.It("should auto activate profile using regular expression matching environment variable substring", func() {
+		tempDir, err := framework.CopyToTempDir("tests/config/testdata/profile-activation")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		// run with non-matching vars
+		configBuffer := &bytes.Buffer{}
+		printCmd := &cmd.PrintCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				ConfigPath: "regexp-substring.yaml",
+			},
+			Out:      configBuffer,
+			SkipInfo: true,
+		}
+
+		os.Setenv("FOO", "the best string")
+		err = printCmd.Run(f)
+		framework.ExpectNoError(err)
+		os.Unsetenv("FOO")
+
+		latestConfig := &latest.Config{}
+		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
+		framework.ExpectNoError(err)
+
+		// validate no profile was activated
+		framework.ExpectEqual(len(latestConfig.Deployments), 0)
+
+		// run with environment variable set.
+		configBuffer = &bytes.Buffer{}
+		printCmd = &cmd.PrintCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				ConfigPath: "regexp-substring.yaml",
+			},
+			Out:      configBuffer,
+			SkipInfo: true,
+		}
+
+		os.Setenv("FOO", "a test string")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 		os.Unsetenv("FOO")

--- a/e2e/tests/config/testdata/profile-activation/regexp-exact.yaml
+++ b/e2e/tests/config/testdata/profile-activation/regexp-exact.yaml
@@ -1,9 +1,9 @@
-version: v1beta10
+version: v1beta11
 profiles:
   - name: one
     activation:
       - env:
-          FOO: "\\^t.*\\$"
+          FOO: "^t.*$"
     patches:
       - op: replace
         path: deployments

--- a/e2e/tests/config/testdata/profile-activation/regexp-substring.yaml
+++ b/e2e/tests/config/testdata/profile-activation/regexp-substring.yaml
@@ -1,9 +1,9 @@
-version: v1beta10
+version: v1beta11
 profiles:
   - name: one
     activation:
       - env:
-          FOO: "\\^t.*\\$"
+          FOO: ".*test.*"
     patches:
       - op: replace
         path: deployments

--- a/e2e/tests/config/testdata/profile-activation/string-exact.yaml
+++ b/e2e/tests/config/testdata/profile-activation/string-exact.yaml
@@ -1,9 +1,9 @@
-version: v1beta10
+version: v1beta11
 profiles:
   - name: one
     activation:
       - env:
-          FOO: "\\^t.*\\$"
+          FOO: "test"
     patches:
       - op: replace
         path: deployments

--- a/pkg/devspace/config/versions/versions.go
+++ b/pkg/devspace/config/versions/versions.go
@@ -2,11 +2,13 @@ package versions
 
 import (
 	"fmt"
-	"github.com/loft-sh/devspace/pkg/devspace/config/versions/v1beta10"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
+
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/v1beta10"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/constants"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/config"
@@ -435,7 +437,11 @@ func getActivatedProfiles(data map[interface{}]interface{}) ([]string, error) {
 
 func matchEnvironment(env map[string]string) (bool, error) {
 	for k, v := range env {
-		match, err := regexp.MatchString(v, os.Getenv(k))
+		expression := strings.TrimPrefix(v, "^")
+		expression = strings.TrimSuffix(expression, "$")
+		expression = fmt.Sprintf("^%s$", expression)
+
+		match, err := regexp.MatchString(expression, os.Getenv(k))
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
### Changes
- Prevents substring matches from activating profiles. For example: an expression `test` should not match `test123`