### PR TITLE
refactor: use replacePods[*].containerName if persitPath.containerName not found

### DIFF
--- a/pkg/devspace/services/podreplace/persist.go
+++ b/pkg/devspace/services/podreplace/persist.go
@@ -37,12 +37,16 @@ func persistPaths(podName string, replacePod *latest.ReplacePod, copiedPod *core
 		}
 
 		if len(copiedPod.Spec.Containers) > 1 && p.ContainerName == "" {
-			names := []string{}
-			for _, c := range copiedPod.Spec.Containers {
-				names = append(names, c.Name)
+			if replacePod.ContainerName == "" {
+				names := []string{}
+				for _, c := range copiedPod.Spec.Containers {
+					names = append(names, c.Name)
+				}
+
+				return fmt.Errorf("couldn't persist path %s as multiple containers were found %s, but no containerName was specified", p.Path, strings.Join(names, " "))
 			}
 
-			return fmt.Errorf("couldn't persist path %s as multiple containers were found %s, but no containerName was specified", p.Path, strings.Join(names, " "))
+			p.ContainerName = replacePod.ContainerName
 		}
 
 		var container *corev1.Container


### PR DESCRIPTION
### Changes
- DevSpace will now use the `replacePods[*].containerName` if multiple containers are found within a replaced pod and no `replacePods[*].persistPaths[*].containerName` is defined