### PR TITLE
fix: don't fail if folder doesn't exist & logging

### DIFF
--- a/pkg/devspace/services/podreplace/persist.go
+++ b/pkg/devspace/services/podreplace/persist.go
@@ -72,7 +72,7 @@ func persistPaths(podName string, replacePod *latest.ReplacePod, copiedPod *core
 			Name:    fmt.Sprintf("path-%d-init", i),
 			Image:   container.Image,
 			Command: []string{"sh"},
-			Args:    []string{"-c", fmt.Sprintf("if [ ! -d \"/devspace-persistence/.devspace/\" ]; then cp -a %s/. /devspace-persistence/ && mkdir /devspace-persistence/.devspace ; fi", path.Clean(p.Path))},
+			Args:    []string{"-c", fmt.Sprintf("if [ ! -d \"/devspace-persistence/.devspace/\" ] && [ -d \"%s\" ]; then cp -a %s/. /devspace-persistence/ && mkdir /devspace-persistence/.devspace ; fi", path.Clean(p.Path), path.Clean(p.Path))},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "devspace-persistence",


### PR DESCRIPTION
### Changes
- Fixed an issue where DevSpace would create a failing pod if the persistence path would not exist in the target container