### PR TITLE
Show file system events for sync in debug

### DIFF
--- a/pkg/devspace/sync/evaluater.go
+++ b/pkg/devspace/sync/evaluater.go
@@ -141,7 +141,7 @@ func shouldRemoveLocal(absFilepath string, fileInformation *FileInformation, s *
 	// We don't delete the file if we haven't tracked it
 	if stat != nil && s.fileIndex.fileMap[fileInformation.Name] != nil {
 		if stat.IsDir() != s.fileIndex.fileMap[fileInformation.Name].IsDirectory || stat.IsDir() != fileInformation.IsDirectory {
-			s.log.Infof("Skip %s because stat returned unequal isdir with fileMap", absFilepath)
+			s.log.Debugf("Skip %s because stat returned unequal isdir with fileMap", absFilepath)
 			return false
 		}
 
@@ -153,7 +153,7 @@ func shouldRemoveLocal(absFilepath string, fileInformation *FileInformation, s *
 					return true
 				}
 
-				s.log.Infof("Skip %s because stat.ModTime() %d is greater than fileInformation.Mtime %d", absFilepath, stat.ModTime().Unix(), fileInformation.Mtime)
+				s.log.Debugf("Skip %s because stat.ModTime() %d is greater than fileInformation.Mtime %d", absFilepath, stat.ModTime().Unix(), fileInformation.Mtime)
 			} else {
 				// s.log.Infof("Skip %s because Mtime (%d and %d) or Size (%d and %d) is unequal between fileInformation and fileMap", absFilepath, fileInformation.Mtime, s.fileIndex.fileMap[fileInformation.Name].Mtime, fileInformation.Size, s.fileIndex.fileMap[fileInformation.Name].Size)
 				return true

--- a/pkg/devspace/sync/upstream.go
+++ b/pkg/devspace/sync/upstream.go
@@ -475,6 +475,7 @@ func (u *upstream) evaluateChange(relativePath, fullpath string) (*FileInformati
 				}
 			}
 		} else if err != nil {
+			u.sync.log.Debugf("Error in lstat %s: %v", fullpath, err)
 			return nil, nil
 		} else if stat == nil {
 			return nil, nil

--- a/pkg/devspace/sync/upstream.go
+++ b/pkg/devspace/sync/upstream.go
@@ -403,6 +403,8 @@ func (u *upstream) getFileInformationFromEvent(events []notify.EventInfo) ([]*Fi
 		if ok {
 			changes = append(changes, fileInfo)
 		} else {
+			u.sync.log.Debugf("Upstream - Event from filesystem for %s", event.Path())
+
 			// check if path is correct
 			fullPath := event.Path()
 			if !strings.HasPrefix(filepath.ToSlash(fullPath), filepath.ToSlash(u.sync.LocalPath)+"/") {
@@ -490,7 +492,7 @@ func (u *upstream) evaluateChange(relativePath, fullpath string) (*FileInformati
 			IsDirectory:    stat.IsDir(),
 			IsSymbolicLink: stat.Mode()&os.ModeSymlink != 0,
 		}
-		if shouldUpload(u.sync, fileInfo) {
+		if shouldUpload(u.sync, fileInfo, u.sync.log) {
 			// New Create Task
 			return fileInfo, nil
 		}
@@ -670,7 +672,7 @@ func (u *upstream) ExecuteBatchCommand() error {
 func (u *upstream) updateUploadChanges(files []*FileInformation) []*FileInformation {
 	newChanges := make([]*FileInformation, 0, len(files))
 	for _, change := range files {
-		if shouldUpload(u.sync, change) {
+		if shouldUpload(u.sync, change, u.sync.log) {
 			newChanges = append(newChanges, change)
 		}
 	}


### PR DESCRIPTION
### Changes
- DevSpace will now print all filesystem events it receives for syncing files if `--debug` is specified and show if a file wasn't synced