### PR TITLE
refactor: add containername to error messages

### DIFF
--- a/pkg/devspace/kubectl/selector/selector.go
+++ b/pkg/devspace/kubectl/selector/selector.go
@@ -96,7 +96,11 @@ func (s Selector) String() string {
 		strs = append(strs, "image selector: "+strings.Join(sa, ","))
 	}
 	if len(s.LabelSelector) > 0 {
-		strs = append(strs, "label selector: "+s.LabelSelector)
+		if s.ContainerName != "" {
+			strs = append(strs, "label selector: "+s.LabelSelector+" - container: "+s.ContainerName)
+		} else {
+			strs = append(strs, "label selector: "+s.LabelSelector)
+		}
 	}
 	if s.Pod != "" {
 		strs = append(strs, "pod name: "+s.Pod)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**Please provide a short message that should be published in the DevSpace release notes**
Adds the container name to error messages like `couldn't find pod / container with label selector ...`

