### PR TITLE
fix: allow matching of integers using older patch path syntax

### DIFF
--- a/pkg/devspace/config/loader/patch/operation_test.go
+++ b/pkg/devspace/config/loader/patch/operation_test.go
@@ -320,6 +320,46 @@ func TestRemoveOperation(t *testing.T) {
 					- name: devbackend
 			`,
 		},
+		"remove nested item matched by numeric property from array by string or numeric filter": {
+			input: `
+                dev:
+                    ports:
+                    - name: rails
+                      reverseForward:
+                      - port: 9200
+                        remotePort: 9200
+			`,
+			operation: &Operation{
+				Op:   opRemove,
+				Path: "dev.ports[?(@.name=='rails')].reverseForward[?(@.port==9200 || @.port=='9200')]",
+			},
+			expected: `
+                dev:
+                    ports:
+                    - name: rails
+                      reverseForward: []
+			`,
+		},
+		"remove nested item matched by string property from array by string or numeric filter": {
+			input: `
+                dev:
+                    ports:
+                    - name: rails
+                      reverseForward:
+                      - port: '9200'
+                        remotePort: '9200'
+			`,
+			operation: &Operation{
+				Op:   opRemove,
+				Path: "dev.ports[?(@.name=='rails')].reverseForward[?(@.port==9200 || @.port=='9200')]",
+			},
+			expected: `
+				dev:
+                    ports:
+                    - name: rails
+                      reverseForward: []
+			`,
+		},
 		"remove no match": {
 			input: `
 				deployments:

--- a/pkg/devspace/config/loader/profile.go
+++ b/pkg/devspace/config/loader/profile.go
@@ -221,6 +221,7 @@ var hasFilterRegEx = regexp.MustCompile(`(?i)\[\?.*\)\]`)
 var indexXPathRegEx = regexp.MustCompile(`\/(\d+|\*)\/`)
 var trailingIndexXPathRegEx = regexp.MustCompile(`\/(\d+|\*)$`)
 var rootXPathRegEx = regexp.MustCompile(`^\/`)
+var numeric = regexp.MustCompile(`^\d+$`)
 
 func transformPath(path string) string {
 	if path == "" {
@@ -237,7 +238,11 @@ func transformPath(path string) string {
 			rewriteToken := token
 			if legacyExtendedSyntaxRegEx.MatchString(token) {
 				filterTokens := legacyExtendedSyntaxRegEx.FindStringSubmatch(token)
-				rewriteToken = fmt.Sprintf("[?(@.%s=='%s')]", filterTokens[1], filterTokens[2])
+				if numeric.MatchString((filterTokens[2])) {
+					rewriteToken = fmt.Sprintf("[?(@.%s=='%s' || @.%s==%s)]", filterTokens[1], filterTokens[2], filterTokens[1], filterTokens[2])
+				} else {
+					rewriteToken = fmt.Sprintf("[?(@.%s=='%s')]", filterTokens[1], filterTokens[2])
+				}
 			}
 			rewriteTokens = append(rewriteTokens, rewriteToken)
 		}

--- a/pkg/devspace/config/loader/profile_test.go
+++ b/pkg/devspace/config/loader/profile_test.go
@@ -26,6 +26,7 @@ func TestTransformPath(t *testing.T) {
 		`deployments[?(@.name=='staging1')]`:                 `deployments[?(@.name=='staging1')]`,
 		`deployments[?(@.helm.timeout > 1000)]`:              `deployments[?(@.helm.timeout > 1000)]`,
 		`deployments.name=backend.helm.values.containers.image=john/devbackend.image`: `deployments[?(@.name=='backend')].helm.values.containers[?(@.image=='john/devbackend')].image`,
+		`dev.ports.name=rails.reverseForward.port=9200`:                               `dev.ports[?(@.name=='rails')].reverseForward[?(@.port=='9200' || @.port==9200)]`,
 	}
 
 	// Run test cases


### PR DESCRIPTION
### Changes

- modify patch path conversion to account for possible integer types.

### Notes
- This does not account for floating point numbers, but that is unlikely to be needed