### PR TITLE
fix: prevent generated update in `devspace` command building

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -96,8 +96,7 @@ devspace --dependency my-dependency run any-command --any-command-flag
 		},
 	}
 
-	logger := f.GetLog()
-	commands, _ := getCommands(f, logger)
+	commands, _ := getCommands(f)
 	for _, command := range commands {
 		description := command.Description
 		if description == "" {
@@ -200,7 +199,7 @@ func (cmd *RunCmd) RunRun(f factory.Factory, args []string) error {
 	return dependency.ExecuteCommand(commands, args[0], args[1:], cmd.Stdout, cmd.Stderr)
 }
 
-func getCommands(f factory.Factory, logger log.Logger) ([]*latest.CommandConfig, error) {
+func getCommands(f factory.Factory) ([]*latest.CommandConfig, error) {
 	// get current working dir
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -222,7 +221,7 @@ func getCommands(f factory.Factory, logger log.Logger) ([]*latest.CommandConfig,
 	}
 
 	// Parse commands
-	commandsInterface, err := configLoader.LoadWithParser(loader.NewCommandsParser(), nil, log.Discard)
+	commandsInterface, err := configLoader.LoadWithParser(loader.NewCommandsParser(), &loader.ConfigOptions{Dry: true}, log.Discard)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/config/loader/loader.go
+++ b/pkg/devspace/config/loader/loader.go
@@ -342,6 +342,12 @@ func (l *configLoader) parseConfig(absPath string, rawConfig map[interface{}]int
 		return nil, nil, nil, err
 	}
 
+	// check if we do not want to change the generated config or
+	// secret vars.
+	if options.Dry {
+		return latestConfig, generatedConfig, resolver, nil
+	}
+
 	// Save generated config
 	if options.GeneratedLoader == nil {
 		err = generated.NewConfigLoaderFromDevSpacePath(GetLastProfile(options.Profiles), l.configPath).Save(generatedConfig)

--- a/pkg/devspace/config/loader/options.go
+++ b/pkg/devspace/config/loader/options.go
@@ -14,6 +14,8 @@ func OptionsWithGeneratedConfig(generatedConfig *generated.Config) *ConfigOption
 
 // ConfigOptions defines options to load the config
 type ConfigOptions struct {
+	Dry bool
+
 	// KubeClient is needed if variables were saved in the namespace
 	KubeClient kubectl.Client `yaml:"-" json:"-"`
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would change the generated.yaml in plugin or unrelated commands
