### PR TITLE
devspace init + devspace dev fails

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,5 +1,12 @@
 package cmd
 
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+)
+
 /*import (
 	"io/ioutil"
 	"os"
@@ -303,3 +310,114 @@ func testInit(t *testing.T, testCase initTestCase) {
 	})
 	assert.NilError(t, err, "Error cleaning up in testCase %s", testCase.name)
 }*/
+
+type parseImagesTestCase struct {
+	name      string
+	manifests string
+	expected  []string
+}
+
+func TestParseImages(t *testing.T) {
+	testCases := []parseImagesTestCase{
+		{
+			name: `Single`,
+			manifests: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "new"
+  labels:
+    "app.kubernetes.io/name": "devspace-app"
+    "app.kubernetes.io/component": "test"
+    "app.kubernetes.io/managed-by": "Helm"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      "app.kubernetes.io/name": "devspace-app"
+      "app.kubernetes.io/component": "test"
+      "app.kubernetes.io/managed-by": "Helm"
+  template:
+    metadata:
+      labels:
+        "app.kubernetes.io/name": "devspace-app"
+        "app.kubernetes.io/component": "test"
+        "app.kubernetes.io/managed-by": "Helm"
+    spec:
+      containers:
+        - image: "username/app"
+          name: "container-0"
+`,
+			expected: []string{
+				"username/app",
+			},
+		},
+		{
+			name: `Multiple`,
+			manifests: `
+---
+# Source: my-app/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: php
+  labels:
+    release: "test-helm"
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    release: "test-helm"
+---
+# Source: my-app/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-helm
+  labels:
+    release: "test-helm"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      release: "test-helm"
+  template:
+    metadata:
+      annotations:
+        revision: "1"
+      labels:
+        release: "test-helm"
+    spec:
+      containers:
+      - name: default
+        image: "php"
+`,
+			expected: []string{
+				"php",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		manifests := testCase.manifests
+
+		actual, err := parseImages(manifests)
+		assert.NilError(
+			t,
+			err,
+			"Unexpected error in test case %s",
+			testCase.name,
+		)
+
+		expected := testCase.expected
+		assert.Assert(
+			t,
+			cmp.DeepEqual(expected, actual),
+			"Unexpected values in test case %s",
+			testCase.name,
+		)
+	}
+}

--- a/e2e/framework/util.go
+++ b/e2e/framework/util.go
@@ -91,7 +91,7 @@ func CleanupTempDir(initialDir, tempDir string) {
 }
 
 func CopyToTempDir(relativePath string) (string, error) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir("", "temp-*")
 	if err != nil {
 		return "", err
 	}

--- a/e2e/tests/init/testdata/new/chart/Chart.yaml
+++ b/e2e/tests/init/testdata/new/chart/Chart.yaml
@@ -1,0 +1,3 @@
+name: my-app
+version: v0.0.1
+description: A Kubernetes-Native Application

--- a/e2e/tests/init/testdata/new/chart/templates/deployment.yaml
+++ b/e2e/tests/init/testdata/new/chart/templates/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    release: "{{ .Release.Name }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      release: "{{ .Release.Name }}"
+  template:
+    metadata:
+      annotations:
+        revision: "{{ .Release.Revision }}"
+      labels:
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: default
+        image: "{{ .Values.containers.app.image }}"

--- a/e2e/tests/init/testdata/new/chart/templates/service.yaml
+++ b/e2e/tests/init/testdata/new/chart/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: php
+  labels:
+    release: "{{ .Release.Name }}"
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    release: "{{ .Release.Name }}"

--- a/e2e/tests/init/testdata/new/chart/values.yaml
+++ b/e2e/tests/init/testdata/new/chart/values.yaml
@@ -1,0 +1,5 @@
+containers:
+  app:
+    image: username/app
+
+pullSecrets: []

--- a/e2e/tests/init/testdata/new/kustomization/deployment.yaml
+++ b/e2e/tests/init/testdata/new/kustomization/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "new"
+  labels:
+    "app.kubernetes.io/name": "devspace-app"
+    "app.kubernetes.io/component": "test"
+    "app.kubernetes.io/managed-by": "Helm"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      "app.kubernetes.io/name": "devspace-app"
+      "app.kubernetes.io/component": "test"
+      "app.kubernetes.io/managed-by": "Helm"
+  template:
+    metadata:
+      labels:
+        "app.kubernetes.io/name": "devspace-app"
+        "app.kubernetes.io/component": "test"
+        "app.kubernetes.io/managed-by": "Helm"
+    spec:
+      containers:
+        - image: "username/app"
+          name: "container-0"

--- a/e2e/tests/init/testdata/new/kustomization/kustomization.yaml
+++ b/e2e/tests/init/testdata/new/kustomization/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml

--- a/e2e/tests/init/testdata/new/manifests/deployment.yaml
+++ b/e2e/tests/init/testdata/new/manifests/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "new"
+  labels:
+    "app.kubernetes.io/name": "devspace-app"
+    "app.kubernetes.io/component": "test"
+    "app.kubernetes.io/managed-by": "Helm"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      "app.kubernetes.io/name": "devspace-app"
+      "app.kubernetes.io/component": "test"
+      "app.kubernetes.io/managed-by": "Helm"
+  template:
+    metadata:
+      labels:
+        "app.kubernetes.io/name": "devspace-app"
+        "app.kubernetes.io/component": "test"
+        "app.kubernetes.io/managed-by": "Helm"
+    spec:
+      containers:
+        - image: "username/app"
+          name: "container-0"

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -32,6 +32,14 @@ func (m *manager) AddKubectlDeployment(deploymentName string, isKustomization bo
 					return nil
 				}
 				return fmt.Errorf("path `%s` is not a Kustomization (kustomization.yaml missing)", value)
+			} else {
+				matches, err := filepath.Glob(value)
+				if err != nil {
+					return fmt.Errorf("path `%s` is not a valid glob pattern", value)
+				}
+				if len(matches) == 0 {
+					return fmt.Errorf("path `%s` did not match any manifests", value)
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
### Changes
- `devspace init`: changed `"What is the main container image of this project...?"` question to present images parsed from the given deployment method
- `devspace init`: added tests for component chart, local chart, kubectl and kustomize deployments, and ensured that `devspace dev` can run successfully after accepting defaults
- `devspace init`: validate that the answer given for `"Please enter the paths to your Kubernetes manifests"` matches at least one file
- e2e tests: made temporary directories non-numeric to prevent helm deployment tests from failing

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Resolves an issue where running `devspace init` and `devspace dev` can lead to replace pods timeouts using the freshly generated configuration.

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace init can generate configuration that leads to replace pods timeout
