### PR TITLE
refactor: only show init container logs if --debug is specified

### DIFF
--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -70,7 +70,6 @@ devspace purge -d my-deployment
 
 	purgeCmd.Flags().StringSliceVar(&cmd.SkipDependency, "skip-dependency", []string{}, "Skips the following dependencies from purging")
 	purgeCmd.Flags().StringSliceVar(&cmd.Dependency, "dependency", []string{}, "Purges only the specific named dependencies")
-
 	return purgeCmd
 }
 


### PR DESCRIPTION
### Changes
- Only show init container logs on `--debug`