### PR TITLE
fix: kaniko custom-pull-secret documentation

### DIFF
--- a/docs/pages/configuration/images/kaniko.mdx
+++ b/docs/pages/configuration/images/kaniko.mdx
@@ -196,8 +196,9 @@ hooks:
     - secret
     - generic
     - custom-pull-secret
+    - --type=kubernetes.io/dockerconfigjson
     - --from-literal
-    - config.json='{ "credsStore":"ecr-login" }'
+    - .dockerconfigjson='{ "credsStore":"ecr-login" }'
   when:
     before:
       images: all
@@ -207,16 +208,17 @@ hooks:
 :::note Building AWS ECR images on EKS
 If your EKS instance is [configured with access to ECR (see instance role permissions for AWS EKS and ECR)](https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_on_EKS.html), your pull secret referenced by the `pullSecret` option, could be created with this kubectl command:
 ```yaml
-kubectl create secret generic custom-pull-secret --from-literal config.json='{ "credsStore":"ecr-login" }'
+kubectl create secret generic custom-pull-secret --type=kubernetes.io/dockerconfigjson --from-literal .dockerconfigjson='{ "credsStore":"ecr-login" }'
 ```
 The resulting Kubernetes secret would look like this:
 ```yaml
 apiVersion: v1
 kind: Secret
+type: kubernetes.io/dockerconfigjson
 metadata:
   name: custom-pull-secret
 data:
-  config.json: eyAiY3JlZHNTdG9yZSI6ImVjci1sb2dpbiIgfQ==
+  .dockerconfigjson: eyAiY3JlZHNTdG9yZSI6ImVjci1sb2dpbiIgfQ==
 ```
 If you define `pullSecret: custom-pull-secret` as shown in the example above, DevSpace will automatically mount this secret into the kaniko container and kaniko will be able to pull from and push to ECR.
 :::


### PR DESCRIPTION
Signed-off-by: Taras Bondarchuk <alius.miles@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind documentation


**What does this pull request do? Which issues does it resolve?** 
Fix documentation for kaniko custom pull secret: 

provided examples didn't work because devspace was generating kaniko pod with different key in secret mount (*.dockerconfigjson* instead of *config.json*) with pod getting stuck at init with error: `non-existent secret key: .dockerconfigjson`


**Please provide a short message that should be published in the DevSpace release notes**
Fixed documentation for kaniko custom pull secret examples.


**What else do we need to know?** 
I assume this is caused by following line: https://github.com/loft-sh/devspace/blob/06540363ca7b0495cda9b0875a96224fa6a8965e/pkg/devspace/build/builder/kaniko/build_pod.go#L147 
Reference: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials

Tested on: devspace version 5.18.3
