### PR TITLE
fix: allow container name & image selector together

### DIFF
--- a/pkg/devspace/config/loader/validate.go
+++ b/pkg/devspace/config/loader/validate.go
@@ -385,10 +385,6 @@ func validateDev(config *latest.Config) error {
 	if config.Dev.Ports != nil {
 		for index, port := range config.Dev.Ports {
 			// Validate imageName and label selector
-			if port.ContainerName != "" && len(port.LabelSelector) == 0 {
-				return errors.Errorf("Error in config: containerName is defined but label selector is nil in ports config at index %d", index)
-			}
-
 			if len(port.LabelSelector) == 0 && port.ImageSelector == "" {
 				return errors.Errorf("Error in config: image selector and label selector are nil in ports config at index %d", index)
 			}
@@ -405,10 +401,6 @@ func validateDev(config *latest.Config) error {
 	if config.Dev.Sync != nil {
 		for index, sync := range config.Dev.Sync {
 			// Validate imageName and label selector
-			if sync.ContainerName != "" && len(sync.LabelSelector) == 0 {
-				return errors.Errorf("Error in config: containerName is defined but label selector is nil in sync config at index %d", index)
-			}
-
 			if len(sync.LabelSelector) == 0 && sync.ImageSelector == "" {
 				return errors.Errorf("Error in config: image selector and label selector are nil in sync config at index %d", index)
 			}
@@ -442,9 +434,6 @@ func validateDev(config *latest.Config) error {
 		for index, selector := range config.Dev.Logs.Selectors {
 			if selector.ImageSelector != "" && len(selector.LabelSelector) > 0 {
 				return errors.Errorf("Error in config: dev.logs.selectors[%d].imageSelector and dev.logs.selectors[%d].labelSelector cannot be used together", index, index)
-			}
-			if selector.ImageSelector != "" && selector.ContainerName != "" {
-				return errors.Errorf("Error in config: dev.logs.selectors[%d].imageSelector and dev.logs.selectors[%d].containerName cannot be used together", index, index)
 			}
 		}
 	}

--- a/pkg/devspace/config/loader/validate_test.go
+++ b/pkg/devspace/config/loader/validate_test.go
@@ -96,26 +96,6 @@ func TestValidateDev(t *testing.T) {
 	err := validateDev(config)
 	assert.NilError(t, err)
 
-	config = &latest.Config{
-		Dev: latest.DevConfig{
-			Ports: []*latest.PortForwardingConfig{
-				{
-					ContainerName: "fakeContainer",
-					Name:          "someName",
-					PortMappings: []*latest.PortMapping{
-						{
-							LocalPort:  &localPort,
-							RemotePort: &remotePort,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	err = validateDev(config)
-	assert.Error(t, err, "Error in config: containerName is defined but label selector is nil in ports config at index 0")
-
 	// test sync
 	config = &latest.Config{
 		Dev: latest.DevConfig{
@@ -134,20 +114,6 @@ func TestValidateDev(t *testing.T) {
 
 	err = validateDev(config)
 	assert.NilError(t, err)
-
-	config = &latest.Config{
-		Dev: latest.DevConfig{
-			Sync: []*latest.SyncConfig{
-				{
-					ContainerName: "fakeContainer",
-					Name:          "someName",
-				},
-			},
-		},
-	}
-
-	err = validateDev(config)
-	assert.Error(t, err, "Error in config: containerName is defined but label selector is nil in sync config at index 0")
 
 	// test replace pods
 	config = &latest.Config{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace wasn't able to use `imageSelector` and `containerName` together
