### PR TITLE
Added --set and --set-string flags to run_pipelines and run_default_pipeline commands along with e2e tests

### DIFF
--- a/e2e/tests/pipelines/pipelines.go
+++ b/e2e/tests/pipelines/pipelines.go
@@ -120,6 +120,26 @@ var _ = DevSpaceDescribe("pipelines", func() {
 		}
 	})
 
+	ginkgo.FIt("should get value from config", func() {
+		tempDir, err := framework.CopyToTempDir("tests/pipelines/testdata/getconfigvalue")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		ns, err := kubeClient.CreateNamespace("pipelines")
+		framework.ExpectNoError(err)
+		defer framework.ExpectDeleteNamespace(kubeClient, ns)
+
+		devCmd := &cmd.RunPipelineCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				NoWarn:    true,
+				Namespace: ns,
+			},
+			Pipeline: "dev",
+		}
+		err = devCmd.RunDefault(f)
+		framework.ExpectNoError(err)
+	})
+
 	ginkgo.It("should get value from config", func() {
 		tempDir, err := framework.CopyToTempDir("tests/pipelines/testdata/getconfigvalue")
 		framework.ExpectNoError(err)

--- a/e2e/tests/pipelines/testdata/run_default_pipeline/devspace.yaml
+++ b/e2e/tests/pipelines/testdata/run_default_pipeline/devspace.yaml
@@ -1,0 +1,13 @@
+version: v2beta1
+name: run-pipelines-demo
+
+pipelines:
+  dev: |-
+    run_default_pipeline deploy --set deployments.dev.helm.values.containers[0].image=nginx --set-string deployments.dev.helm.values.containers[0].name=mynginx
+
+deployments:
+  dev:
+    helm:
+      values:
+        containers:
+          - image: alpine

--- a/e2e/tests/pipelines/testdata/run_pipelines/devspace.yaml
+++ b/e2e/tests/pipelines/testdata/run_pipelines/devspace.yaml
@@ -1,0 +1,15 @@
+version: v2beta1
+name: run-pipelines-demo
+
+pipelines:
+  dev: |-
+    run_pipelines deploy --set deployments.dev.helm.values.containers[0].image=nginx --set-string deployments.dev.helm.values.containers[0].name=mynginx
+  deploy: |-
+    create_deployments --all
+
+deployments:
+  dev:
+    helm:
+      values:
+        containers:
+          - image: alpine

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/create_deployments.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/create_deployments.go
@@ -147,7 +147,7 @@ func applySetValues(ctx devspacecontext.Context, name, objName string, set, setS
 			continue
 		}
 
-		err = strvals.ParseInto(s, mapObj)
+		err = strvals.ParseIntoString(s, mapObj)
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing --set-string flag")
 		}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/run_default_pipeline.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/run_default_pipeline.go
@@ -2,13 +2,24 @@ package commands
 
 import (
 	"fmt"
+	"github.com/jessevdk/go-flags"
+	"github.com/loft-sh/devspace/pkg/devspace/config"
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions"
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/util"
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
 	"github.com/loft-sh/devspace/pkg/devspace/pipeline/engine"
 	enginetypes "github.com/loft-sh/devspace/pkg/devspace/pipeline/engine/types"
 	"github.com/loft-sh/devspace/pkg/devspace/pipeline/types"
+	"github.com/loft-sh/devspace/pkg/util/strvals"
+	"github.com/pkg/errors"
 	"io"
 	"mvdan.cc/sh/v3/interp"
 )
+
+type RunDefaultPipelineOptions struct {
+	Set       []string `long:"set" description:"Set configuration"`
+	SetString []string `long:"set-string" description:"Set configuration as string"`
+}
 
 type NewHandlerFn func(ctx devspacecontext.Context, stdout, stderr io.Writer, pipeline types.Pipeline) enginetypes.ExecHandler
 
@@ -19,8 +30,22 @@ func RunDefaultPipeline(ctx devspacecontext.Context, pipeline types.Pipeline, ar
 	}
 
 	hc := interp.HandlerCtx(ctx.Context())
+
+	options := &RunDefaultPipelineOptions{}
+	args, err = flags.ParseArgs(options, args)
+	if err != nil {
+		return errors.Wrap(err, "parse args")
+	}
+
 	if len(args) != 1 {
 		return fmt.Errorf("usage: run_default_pipeline [pipeline]")
+	}
+
+	if len(args) > 0 {
+		ctx, err = applyPipelineSetValue(ctx, options.Set, options.SetString)
+		if err != nil {
+			return err
+		}
 	}
 
 	defaultPipeline, err := types.GetDefaultPipeline(args[0])
@@ -30,4 +55,46 @@ func RunDefaultPipeline(ctx devspacecontext.Context, pipeline types.Pipeline, ar
 
 	_, err = engine.ExecutePipelineShellCommand(ctx.Context(), defaultPipeline.Run, nil, hc.Dir, false, hc.Stdout, hc.Stderr, hc.Stdin, hc.Env, newHandler(ctx, hc.Stdout, hc.Stderr, pipeline))
 	return err
+}
+
+func applyPipelineSetValue(ctx devspacecontext.Context, set, setString []string) (devspacecontext.Context, error) {
+	if len(set) == 0 && len(setString) == 0 {
+		return ctx, nil
+	}
+
+	rawConfigOriginal := ctx.Config().RawBeforeConversion()
+	rawConfig := map[string]interface{}{}
+	err := util.Convert(rawConfigOriginal, &rawConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range set {
+		err = strvals.ParseInto(s, rawConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing --set flag")
+		}
+	}
+
+	for _, s := range setString {
+		err = strvals.ParseIntoString(s, rawConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing --set-string flag")
+		}
+	}
+
+	latestConfig, err := versions.Parse(rawConfig, ctx.Log())
+	if err != nil {
+		return nil, err
+	}
+
+	return ctx.WithConfig(config.NewConfig(
+		ctx.Config().Raw(),
+		rawConfig,
+		latestConfig,
+		ctx.Config().LocalCache(),
+		ctx.Config().RemoteCache(),
+		ctx.Config().Variables(),
+		ctx.Config().Path(),
+	)), nil
 }

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/run_pipelines.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/run_pipelines.go
@@ -13,6 +13,8 @@ import (
 
 type RunPipelineOptions struct {
 	types.PipelineOptions
+	Set       []string `long:"set" description:"Set configuration"`
+	SetString []string `long:"set-string" description:"Set configuration as string"`
 }
 
 func RunPipelines(ctx devspacecontext.Context, pipeline types.Pipeline, args []string, environ expand.Environ) error {
@@ -21,6 +23,13 @@ func RunPipelines(ctx devspacecontext.Context, pipeline types.Pipeline, args []s
 	args, err := flags.ParseArgs(options, args)
 	if err != nil {
 		return errors.Wrap(err, "parse args")
+	}
+
+	if len(args) > 0 {
+		ctx, err = applyPipelineSetValue(ctx, options.Set, options.SetString)
+		if err != nil {
+			return err
+		}
 	}
 
 	pipelines := []*latest.Pipeline{}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
Added --set and --set-string flags to run_pipelines and run_default_pipeline commands
/kind test
Added e2e tests for both run_pipelines and run_default_pipeline new flags
**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #
Two flags are now available for run_pipelines and run_default_pipeline.

**Please provide a short message that should be published in the DevSpace release notes**
NA

**What else do we need to know?** 
NA