### PR TITLE
Bump kaniko default version from v1.6.0 to v1.8.1

### DIFF
--- a/docs/pages/configuration/images/kaniko.mdx
+++ b/docs/pages/configuration/images/kaniko.mdx
@@ -142,7 +142,7 @@ The `image` option expects a string stating the image that should be used for th
 
 #### Default Value For `image`
 ```yaml
-image: gcr.io/kaniko-project/executor:v0.17.1
+image: gcr.io/kaniko-project/executor:v1.8.1
 ```
 
 #### Example: Use Different Kaniko Image/Version
@@ -152,7 +152,7 @@ images:
     image: 123.456.789.0:5000/john/appbackend
     build:
       kaniko:
-        image: gcr.io/kaniko-project/executor:v0.19.0
+        image: gcr.io/kaniko-project/executor:v1.6.0
 ```
 
 ### `initImage`

--- a/pkg/devspace/build/builder/kaniko/build_pod.go
+++ b/pkg/devspace/build/builder/kaniko/build_pod.go
@@ -24,7 +24,7 @@ import (
 const kanikoInitImage = "alpine"
 
 // The kaniko build image we use by default
-const kanikoBuildImage = "gcr.io/kaniko-project/executor:v1.6.0"
+const kanikoBuildImage = "gcr.io/kaniko-project/executor:v1.8.1"
 
 // The context path within the kaniko pod
 const kanikoContextPath = "/context"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


I'm hitting [this pretty nasty bug](https://github.com/GoogleContainerTools/kaniko/issues/1262) with kaniko that seems to be fixed with kaniko 1.8+. I tested with 1.8.1 by overriding the value in devspace.yaml and it solves it.

1.6.0 is a year old so figured it would be a good idea to get devspace aligned with the most recent version.
also updated the documentation, it was misaligned with the current default.

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #

Upgrade default kaniko version

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace ...

Update default kaniko version from v1.6.0 to v1.8.1

**What else do we need to know?** 
