### PR TITLE
removed fake k8s client

### DIFF
--- a/pkg/devspace/dependency/registry/registry.go
+++ b/pkg/devspace/dependency/registry/registry.go
@@ -133,7 +133,7 @@ func (d *dependencyRegistry) MarkDependenciesExcluded(ctx devspacecontext.Contex
 
 func (d *dependencyRegistry) excludeDependencies(ctx devspacecontext.Context, dependencyNames []string, forceLeader bool, retries int) (map[string]bool, error) {
 	retMap := map[string]bool{}
-	if len(dependencyNames) == 0 {
+	if len(dependencyNames) == 0 || ctx.KubeClient() == nil {
 		return retMap, nil
 	}
 

--- a/pkg/devspace/kubectl/util/util.go
+++ b/pkg/devspace/kubectl/util/util.go
@@ -27,7 +27,7 @@ func NewClientByContext(context, namespace string, switchContext bool, kubeLoade
 		// try to load in cluster config
 		config, err := rest.InClusterConfig()
 		if err != nil {
-			return nil, "", "", false, errors.Errorf("kube config is invalid: please make sure you have an existing valid kube config. You might want to check one of the following things:\n\n* Make sure you can use 'kubectl get namespaces' locally\n* If you are using Loft, you might want to run 'devspace create space' or 'loft create space'\n")
+			return nil, "", "", false, errors.Errorf("kube config is invalid")
 		}
 
 		currentNamespace, err := inClusterNamespace()

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/build_images.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/build_images.go
@@ -24,15 +24,17 @@ type BuildImagesOptions struct {
 
 func BuildImages(ctx devspacecontext.Context, pipeline types.Pipeline, args []string) error {
 	ctx.Log().Debugf("build_images %s", strings.Join(args, " "))
-	err := pipeline.Exclude(ctx)
-	if err != nil {
-		return err
+	if ctx.KubeClient() != nil {
+		err := pipeline.Exclude(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	options := &BuildImagesOptions{
 		Options: pipeline.Options().BuildOptions,
 	}
-	args, err = flags.ParseArgs(options, args)
+	args, err := flags.ParseArgs(options, args)
 	if err != nil {
 		return errors.Wrap(err, "parse args")
 	}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/create_deployments.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/create_deployments.go
@@ -29,13 +29,17 @@ type CreateDeploymentsOptions struct {
 	All bool `long:"all" description:"Deploy all deployments"`
 }
 
+const ErrMsg = "Please make sure you have an existing valid kube config. You might want to check one of the following things:\n\n* Make sure you can use 'kubectl get namespaces' locally\n* If you are using Loft, you might want to run 'devspace create space' or 'loft create space'\n"
+
 func CreateDeployments(ctx devspacecontext.Context, pipeline types.Pipeline, args []string, stdout io.Writer) error {
 	ctx.Log().Debugf("create_deployments %s", strings.Join(args, " "))
 	err := pipeline.Exclude(ctx)
 	if err != nil {
 		return err
 	}
-
+	if ctx.KubeClient() == nil {
+		return errors.Errorf(ErrMsg)
+	}
 	options := &CreateDeploymentsOptions{
 		Options: pipeline.Options().DeployOptions,
 	}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/ensure_pull_secrets.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/ensure_pull_secrets.go
@@ -27,7 +27,9 @@ func EnsurePullSecrets(ctx devspacecontext.Context, pipeline types.Pipeline, arg
 	if err != nil {
 		return err
 	}
-
+	if ctx.KubeClient() == nil {
+		return errors.Errorf(ErrMsg)
+	}
 	options := &EnsurePullSecretsOptions{}
 	args, err = flags.ParseArgs(options, args)
 	if err != nil {

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/exec_container.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/exec_container.go
@@ -23,6 +23,9 @@ type ExecContainerOptions struct {
 
 func ExecContainer(ctx devspacecontext.Context, args []string) error {
 	hc := interp.HandlerCtx(ctx.Context())
+	if ctx.KubeClient() == nil {
+		return errors.Errorf(ErrMsg)
+	}
 	options := &ExecContainerOptions{
 		Namespace: ctx.KubeClient().Namespace(),
 	}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/purge_deployments.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/purge_deployments.go
@@ -27,7 +27,9 @@ func PurgeDeployments(ctx devspacecontext.Context, pipeline types.Pipeline, args
 	if err != nil {
 		return err
 	}
-
+	if ctx.KubeClient() == nil {
+		return errors.Errorf(ErrMsg)
+	}
 	options := &PurgeDeploymentsOptions{
 		PurgeOptions: pipeline.Options().PurgeOptions,
 	}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/select_pod.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/select_pod.go
@@ -22,6 +22,9 @@ type SelectPodOptions struct {
 
 func SelectPod(ctx devspacecontext.Context, args []string) error {
 	hc := interp.HandlerCtx(ctx.Context())
+	if ctx.KubeClient() == nil {
+		return errors.Errorf(ErrMsg)
+	}
 	options := &SelectPodOptions{
 		Namespace: ctx.KubeClient().Namespace(),
 	}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/start_dev.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/start_dev.go
@@ -29,7 +29,9 @@ func StartDev(ctx devspacecontext.Context, pipeline types.Pipeline, args []strin
 	if err != nil {
 		return err
 	}
-
+	if ctx.KubeClient() == nil {
+		return errors.Errorf(ErrMsg)
+	}
 	options := &StartDevOptions{
 		Options: pipeline.Options().DevOptions,
 	}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/stop_dev.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/stop_dev.go
@@ -23,7 +23,9 @@ func StopDev(ctx devspacecontext.Context, pipeline types.Pipeline, args []string
 	if err != nil {
 		return err
 	}
-
+	if ctx.KubeClient() == nil {
+		return errors.Errorf(ErrMsg)
+	}
 	options := &StopDevOptions{
 		PurgeOptions: pipeline.Options().PurgeOptions,
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
Earlier for non-existing kubeconfigs, we used to create fakeclientset, I have removed that logic now. If the kubeconfig is needed  for build operation using kaniko and buildkit, there are already checks present to validate. If the docker build is fired, we don't need k8s cluster, so its now executed without any error.


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace ...


**What else do we need to know?** 
