### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,6 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"strings"
+
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
@@ -13,10 +17,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/util/exit"
 	"github.com/loft-sh/devspace/pkg/util/interrupt"
 	"github.com/loft-sh/devspace/pkg/util/log"
-	"io"
 	"mvdan.cc/sh/v3/interp"
-	"os"
-	"strings"
 
 	"github.com/loft-sh/devspace/cmd/flags"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader"
@@ -284,7 +285,7 @@ func ExecuteCommand(ctx context.Context, cmd *latest.CommandConfig, variables ma
 		if appendArgs {
 			// Append args to shell command
 			for _, arg := range args {
-				arg = strings.Replace(arg, "'", "'\"'\"'", -1)
+				arg = strings.ReplaceAll(arg, "'", "'\"'\"'")
 
 				shellCommand += " '" + arg + "'"
 			}

--- a/e2e/tests/deploy/deploy.go
+++ b/e2e/tests/deploy/deploy.go
@@ -2,6 +2,11 @@ package deploy
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/loft-sh/devspace/cmd"
 	"github.com/loft-sh/devspace/cmd/flags"
 	"github.com/loft-sh/devspace/e2e/framework"
@@ -9,11 +14,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/util/factory"
 	"github.com/onsi/ginkgo"
-	"io/ioutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 var _ = DevSpaceDescribe("deploy", func() {
@@ -107,8 +108,8 @@ var _ = DevSpaceDescribe("deploy", func() {
 		out, err := ioutil.ReadFile(manifests)
 		framework.ExpectNoError(err)
 
-		data := strings.Replace(string(out), "###NAMESPACE1###", ns, -1)
-		data = strings.Replace(data, "###NAMESPACE2###", ns2, -1)
+		data := strings.ReplaceAll(string(out), "###NAMESPACE1###", ns)
+		data = strings.ReplaceAll(data, "###NAMESPACE2###", ns2)
 
 		err = ioutil.WriteFile(manifests, []byte(data), 0777)
 		framework.ExpectNoError(err)

--- a/e2e/tests/replacepods/replacepods.go
+++ b/e2e/tests/replacepods/replacepods.go
@@ -135,7 +135,7 @@ var _ = DevSpaceDescribe("replacepods", func() {
 		fileContents, err := ioutil.ReadFile("devspace.yaml")
 		framework.ExpectNoError(err)
 
-		newString := strings.Replace(string(fileContents), "ubuntu:18.04", "alpine:3.14", -1)
+		newString := strings.ReplaceAll(string(fileContents), "ubuntu:18.04", "alpine:3.14")
 		err = ioutil.WriteFile("devspace.yaml", []byte(newString), 0666)
 		framework.ExpectNoError(err)
 
@@ -237,7 +237,7 @@ var _ = DevSpaceDescribe("replacepods", func() {
 		fileContents, err := ioutil.ReadFile("devspace.yaml")
 		framework.ExpectNoError(err)
 
-		newString := strings.Replace(string(fileContents), "ubuntu:18.04", "alpine:3.14", -1)
+		newString := strings.ReplaceAll(string(fileContents), "ubuntu:18.04", "alpine:3.14")
 		err = ioutil.WriteFile("devspace.yaml", []byte(newString), 0666)
 		framework.ExpectNoError(err)
 

--- a/helper/server/tar.go
+++ b/helper/server/tar.go
@@ -3,7 +3,6 @@ package server
 import (
 	"archive/tar"
 	"compress/gzip"
-	"github.com/loft-sh/devspace/pkg/util/fsutil"
 	"io"
 	"io/ioutil"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/loft-sh/devspace/pkg/util/fsutil"
 
 	"github.com/pkg/errors"
 )
@@ -275,7 +276,7 @@ func tarFile(basePath string, fileInformation *fileInformation, writtenFiles map
 }
 
 func getRelativeFromFullPath(fullpath string, prefix string) string {
-	return strings.TrimPrefix(strings.Replace(strings.Replace(fullpath[len(prefix):], "\\", "/", -1), "//", "/", -1), ".")
+	return strings.TrimPrefix(strings.ReplaceAll(strings.ReplaceAll(fullpath[len(prefix):], "\\", "/"), "//", "/"), ".")
 }
 
 func createFileInformationFromStat(relativePath string, stat os.FileInfo) *fileInformation {

--- a/pkg/devspace/config/loader/loader_test.go
+++ b/pkg/devspace/config/loader/loader_test.go
@@ -2106,7 +2106,7 @@ profiles:
 	// Execute test cases
 	for index, testCase := range testCases {
 		testMap := map[string]interface{}{}
-		err := yaml.Unmarshal([]byte(strings.Replace(testCase.in.config, "	", "  ", -1)), &testMap)
+		err := yaml.Unmarshal([]byte(strings.ReplaceAll(testCase.in.config, "	", "  ")), &testMap)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/devspace/config/loader/variable/legacy/replace.go
+++ b/pkg/devspace/config/loader/variable/legacy/replace.go
@@ -2,13 +2,13 @@ package legacy
 
 import (
 	"fmt"
-	"github.com/loft-sh/devspace/pkg/util/dockerfile"
 	"regexp"
 	"strings"
 
 	buildtypes "github.com/loft-sh/devspace/pkg/devspace/build/types"
 	"github.com/loft-sh/devspace/pkg/devspace/config/constants"
 	"github.com/loft-sh/devspace/pkg/devspace/imageselector"
+	"github.com/loft-sh/devspace/pkg/util/dockerfile"
 
 	config2 "github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
@@ -132,7 +132,7 @@ func resolveImage(value string, config config2.Config, dependencies []types.Depe
 
 		// does the config have a tag defined?
 		if tag == "" && len(configImage.Tags) > 0 {
-			tag = strings.Replace(configImage.Tags[0], "#", "x", -1)
+			tag = strings.ReplaceAll(configImage.Tags[0], "#", "x")
 		}
 
 		// only return the tag

--- a/pkg/devspace/config/loader/variable/resolver.go
+++ b/pkg/devspace/config/loader/variable/resolver.go
@@ -3,13 +3,14 @@ package variable
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/expression"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/runtime"
 	"github.com/loft-sh/devspace/pkg/devspace/config/localcache"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/graph"
-	"path/filepath"
-	"regexp"
-	"strings"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer/kubectl/walk"
@@ -233,8 +234,8 @@ func (r *resolver) insertVariableGraph(g *graph.Graph, node *latest.Variable) er
 func (r *resolver) FillVariablesInclude(ctx context.Context, haystack interface{}, includedPaths []string) (interface{}, error) {
 	paths := []*regexp.Regexp{}
 	for _, path := range includedPaths {
-		path = strings.Replace(path, "*", "[^/]+", -1)
-		path = strings.Replace(path, "**", ".+", -1)
+		path = strings.ReplaceAll(path, "*", "[^/]+")
+		path = strings.ReplaceAll(path, "**", ".+")
 		path = "^" + path
 		expr, err := regexp.Compile(path)
 		if err != nil {
@@ -263,8 +264,8 @@ func (r *resolver) FillVariablesInclude(ctx context.Context, haystack interface{
 func (r *resolver) FillVariablesExclude(ctx context.Context, haystack interface{}, excludedPaths []string) (interface{}, error) {
 	paths := []*regexp.Regexp{}
 	for _, path := range excludedPaths {
-		path = strings.Replace(path, "*", "[^/]+", -1)
-		path = strings.Replace(path, "**", ".+", -1)
+		path = strings.ReplaceAll(path, "*", "[^/]+")
+		path = strings.ReplaceAll(path, "**", ".+")
 		path = "^" + path
 		expr, err := regexp.Compile(path)
 		if err != nil {

--- a/pkg/devspace/config/loader/variable/runtime/runtime_variable.go
+++ b/pkg/devspace/config/loader/variable/runtime/runtime_variable.go
@@ -2,12 +2,13 @@ package runtime
 
 import (
 	"fmt"
+	"strings"
+
 	buildtypes "github.com/loft-sh/devspace/pkg/devspace/build/types"
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/config/constants"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 var Locations = []string{
@@ -181,7 +182,7 @@ func BuildImageString(c config.Config, name string, fallbackImage string, fallba
 	if imageCache.Tag != "" {
 		tag = imageCache.Tag
 	} else if fallbackTag != "" {
-		tag = strings.Replace(fallbackTag, "#", "x", -1)
+		tag = strings.ReplaceAll(fallbackTag, "#", "x")
 	}
 
 	// only return the tag

--- a/pkg/devspace/config/versions/v1beta11/upgrade.go
+++ b/pkg/devspace/config/versions/v1beta11/upgrade.go
@@ -388,7 +388,7 @@ func (c *Config) Upgrade(log log.Logger) (config.Config, error) {
 	devPipeline := deployPipeline + "\n" + "start_dev --all" + "\n"
 	if c.Dev.Terminal != nil && c.Dev.Terminal.ImageSelector == "" && len(c.Dev.Terminal.LabelSelector) == 0 && len(c.Dev.Terminal.Command) > 0 {
 		for _, c := range c.Dev.Terminal.Command {
-			devPipeline += "'" + strings.Replace(c, "'", "'\"'\"'", -1) + "' "
+			devPipeline += "'" + strings.ReplaceAll(c, "'", "'\"'\"'") + "' "
 		}
 
 		devPipeline += "\n"

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl.go
@@ -62,7 +62,7 @@ func New(ctx devspacecontext.Context, deployConfig *latest.DeploymentConfig) (de
 
 	manifests := []string{}
 	for _, ptrManifest := range deployConfig.Kubectl.Manifests {
-		manifest := strings.Replace(ptrManifest, "*", "", -1)
+		manifest := strings.ReplaceAll(ptrManifest, "*", "")
 		if deployConfig.Kubectl.Kustomize != nil && *deployConfig.Kubectl.Kustomize {
 			manifest = strings.TrimSuffix(manifest, "kustomization.yaml")
 		}

--- a/pkg/devspace/imageselector/image_selector.go
+++ b/pkg/devspace/imageselector/image_selector.go
@@ -2,11 +2,12 @@ package imageselector
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/util/dockerfile"
-	"regexp"
-	"strings"
 )
 
 type ImageSelector struct {
@@ -35,7 +36,7 @@ func Resolve(configImageName string, config config.Config, dependencies []types.
 		if c.Images != nil && c.Images[configImageName] != nil {
 			if len(c.Images[configImageName].Tags) > 0 {
 				return &ImageSelector{
-					Image: c.Images[configImageName].Image + ":" + strings.Replace(c.Images[configImageName].Tags[0], "#", "x", -1),
+					Image: c.Images[configImageName].Image + ":" + strings.ReplaceAll(c.Images[configImageName].Tags[0], "#", "x"),
 				}, nil
 			}
 
@@ -81,7 +82,7 @@ func CompareImageNames(selector string, image2 string) bool {
 	// we replace possible # with a's here to avoid an parsing error
 	// since the tag is stripped anyways it doesn't really matter if we lose
 	// information where the # were
-	tagStrippedImage1, _, err := dockerfile.GetStrippedDockerImageName(strings.Replace(image1, "#", "a", -1))
+	tagStrippedImage1, _, err := dockerfile.GetStrippedDockerImageName(strings.ReplaceAll(image1, "#", "a"))
 	if err != nil {
 		tagStrippedImage1 = image1
 	}
@@ -98,7 +99,7 @@ func CompareImageNames(selector string, image2 string) bool {
 
 		// if the tag consists of a # we build a regex
 		if strings.Contains(image1, "#") {
-			regex := "^" + strings.Replace(image1, "#", "[a-zA-Z]", -1) + "$"
+			regex := "^" + strings.ReplaceAll(image1, "#", "[a-zA-Z]") + "$"
 			exp, err := regexp.Compile(regex)
 			if err == nil {
 				return exp.MatchString(image2)

--- a/pkg/devspace/services/podreplace/builder.go
+++ b/pkg/devspace/services/podreplace/builder.go
@@ -72,7 +72,7 @@ func buildDeployment(ctx devspacecontext.Context, name string, target runtime.Ob
 		podTemplate.Labels = t.Spec.Template.Labels
 		podTemplate.Annotations = t.Spec.Template.Annotations
 		podTemplate.Spec = *t.Spec.Template.Spec.DeepCopy()
-		podTemplate.Spec.Hostname = strings.Replace(t.Name+"-0", ".", "-", -1)
+		podTemplate.Spec.Hostname = strings.ReplaceAll(t.Name+"-0", ".", "-")
 		for _, pvc := range t.Spec.VolumeClaimTemplates {
 			pvcName := pvc.Name
 			if pvcName == "" {

--- a/pkg/devspace/sync/sync_test.go
+++ b/pkg/devspace/sync/sync_test.go
@@ -503,13 +503,13 @@ func makeRemoveAndRenameTestCases(filesToCheck testCaseList, foldersToCheck test
 func makeRemoteTestCases(testCases testCaseList) testCaseList {
 	for _, f := range testCases {
 		if strings.Contains(f.path, "Upload") {
-			f.path = strings.Replace(f.path, "Upload", "Download", -1)
+			f.path = strings.ReplaceAll(f.path, "Upload", "Download")
 		} else {
-			f.path = strings.Replace(f.path, "Download", "Upload", -1)
+			f.path = strings.ReplaceAll(f.path, "Download", "Upload")
 		}
 
 		remoteEquivalent := checkedFileOrFolder{
-			path:                strings.Replace(f.path, "Local", "Remote", -1),
+			path:                strings.ReplaceAll(f.path, "Local", "Remote"),
 			shouldExistInLocal:  f.shouldExistInRemote,
 			shouldExistInRemote: f.shouldExistInLocal,
 			editLocation:        editInRemote,

--- a/pkg/devspace/sync/util.go
+++ b/pkg/devspace/sync/util.go
@@ -6,5 +6,5 @@ import (
 )
 
 func getRelativeFromFullPath(fullPath string, prefix string) string {
-	return strings.TrimPrefix(strings.Replace(filepath.ToSlash(fullPath[len(prefix):]), "//", "/", -1), ".")
+	return strings.TrimPrefix(strings.ReplaceAll(filepath.ToSlash(fullPath[len(prefix):]), "//", "/"), ".")
 }

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -19,7 +19,7 @@ func SafeConcatNameMax(name []string, max int) string {
 	fullPath := strings.Join(name, "-")
 	if len(fullPath) > max {
 		digest := sha256.Sum256([]byte(fullPath))
-		return strings.Replace(fullPath[0:max-8]+"-"+hex.EncodeToString(digest[0:])[0:7], ".-", "-", -1)
+		return strings.ReplaceAll(fullPath[0:max-8]+"-"+hex.EncodeToString(digest[0:])[0:7], ".-", "-")
 	}
 	return fullPath
 }

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -2,15 +2,16 @@ package flags
 
 import (
 	"fmt"
-	"github.com/loft-sh/devspace/pkg/devspace/env"
 	"strings"
+
+	"github.com/loft-sh/devspace/pkg/devspace/env"
 
 	"github.com/spf13/cobra"
 )
 
 // ApplyExtraFlags args parses the flags for a certain command from the environment variables
 func ApplyExtraFlags(cobraCmd *cobra.Command, osArgs []string, forceParsing bool) ([]string, error) {
-	envName := strings.ToUpper(strings.Replace(cobraCmd.CommandPath(), " ", "_", -1) + "_FLAGS")
+	envName := strings.ToUpper(strings.ReplaceAll(cobraCmd.CommandPath(), " ", "_") + "_FLAGS")
 
 	flags, err := ParseCommandLine(env.GlobalGetEnv("DEVSPACE_FLAGS"))
 	if err != nil {

--- a/pkg/util/yamlutil/yaml.go
+++ b/pkg/util/yamlutil/yaml.go
@@ -44,11 +44,11 @@ func prettifyError(data []byte, err error) error {
 	// check if type error
 	if typeError, ok := err.(*yaml.TypeError); ok {
 		for i := range typeError.Errors {
-			typeError.Errors[i] = strings.Replace(typeError.Errors[i], "!!seq", "an array", -1)
-			typeError.Errors[i] = strings.Replace(typeError.Errors[i], "!!str", "string", -1)
-			typeError.Errors[i] = strings.Replace(typeError.Errors[i], "!!map", "an object", -1)
-			typeError.Errors[i] = strings.Replace(typeError.Errors[i], "!!int", "number", -1)
-			typeError.Errors[i] = strings.Replace(typeError.Errors[i], "!!bool", "boolean", -1)
+			typeError.Errors[i] = strings.ReplaceAll(typeError.Errors[i], "!!seq", "an array")
+			typeError.Errors[i] = strings.ReplaceAll(typeError.Errors[i], "!!str", "string")
+			typeError.Errors[i] = strings.ReplaceAll(typeError.Errors[i], "!!map", "an object")
+			typeError.Errors[i] = strings.ReplaceAll(typeError.Errors[i], "!!int", "number")
+			typeError.Errors[i] = strings.ReplaceAll(typeError.Errors[i], "!!bool", "boolean")
 
 			// add line to error
 			match := lineRegEx.FindSubmatch([]byte(typeError.Errors[i]))


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.

**Please provide a short message that should be published in the DevSpace release notes**
N/A, this is a non-user facing change

**What else do we need to know?** 
