### PR TITLE
fix: use discard logger when init command renders helm charts

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -732,6 +732,7 @@ func (cmd *InitCmd) render(f factory.Factory, config *latest.Config) (string, er
 		SkipBuild:    true,
 		Render:       true,
 		RenderWriter: writer,
+		Log:          &log.DiscardLogger{},
 	}
 	err = renderCmd.RunDefault(f)
 	if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
Fixes a fatal error that's thrown when prompting the user for which image they would like to develop with DevSpace:

```sh
? Please specify the name of the chart within your chart repository (e.g. payment-service) sealed-secrets
fatal cannot ask question 'Which image do you want to develop with DevSpace?' because log level is too low
github.com/loft-sh/devspace/pkg/util/log.(*StreamLogger).Question
        /Users/runner/work/devspace/devspace/pkg/util/log/stream_logger.go:525
github.com/loft-sh/devspace/cmd.(*InitCmd).initDevspace
        /Users/runner/work/devspace/devspace/cmd/init.go:354
github.com/loft-sh/devspace/cmd.(*InitCmd).Run
        /Users/runner/work/devspace/devspace/cmd/init.go:160
github.com/loft-sh/devspace/cmd.NewInitCmd.func1
        /Users/runner/work/devspace/devspace/cmd/init.go:92
github.com/spf13/cobra.(*Command).execute
        /Users/runner/work/devspace/devspace/vendor/github.com/spf13/cobra/command.go:856
github.com/spf13/cobra.(*Command).ExecuteC
        /Users/runner/work/devspace/devspace/vendor/github.com/spf13/cobra/command.go:974
github.com/spf13/cobra.(*Command).Execute
        /Users/runner/work/devspace/devspace/vendor/github.com/spf13/cobra/command.go:902
github.com/loft-sh/devspace/cmd.Execute
        /Users/runner/work/devspace/devspace/cmd/root.go:134
main.main
        /Users/runner/work/devspace/devspace/main.go:20
runtime.main
        /Users/runner/hostedtoolcache/go/1.17.10/x64/src/runtime/proc.go:255
runtime.goexit
        /Users/runner/hostedtoolcache/go/1.17.10/x64/src/runtime/asm_arm64.s:1133
```


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace `devspace init` would error unexpectedly when prompting for input.
