### PR TITLE
Improvements to devspace init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -347,17 +347,59 @@ func (cmd *InitCmd) initDevspace(f factory.Factory, configLoader loader.ConfigLo
 				return errors.Wrap(err, "error parsing images")
 			}
 
-			if len(images) == 0 {
-				return fmt.Errorf("no images found for the selected deployments")
+			imageManual := "Manually enter the image I want to work on"
+			imageSkip := "Skip (do not add dev configuration for any images)"
+			imageAnswer := ""
+
+			if len(images) > 0 {
+				imageAnswer, err = cmd.log.Question(&survey.QuestionOptions{
+					Question:     "Which image do you want to develop with DevSpace?",
+					DefaultValue: images[0],
+					Options:      append(images, []string{imageManual, imageSkip}...),
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				imageAnswer, err = cmd.log.Question(&survey.QuestionOptions{
+					Question: "Couldn’t find any images in your manifests/helm charts. Do you want to skip this step?",
+					Options:  []string{imageManual, imageSkip},
+				})
+				if err != nil {
+					return err
+				}
 			}
 
-			image, err = cmd.log.Question(&survey.QuestionOptions{
-				Question:     "Which image do you want to develop with DevSpace?",
-				DefaultValue: images[0],
-				Options:      images,
-			})
-			if err != nil {
-				return err
+			if imageAnswer == imageSkip {
+				break
+			} else if imageAnswer == imageManual {
+				imageQuestion := "What is the main container image of this project?"
+
+				if selectedDeploymentOption == DeployOptionHelm {
+					imageQuestion = "What is the main container image of this project which is deployed by this Helm chart? (e.g. ecr.io/project/image)"
+				}
+
+				if selectedDeploymentOption == DeployOptionKubectl {
+					imageQuestion = "What is the main container image of this project which is deployed by these manifests? (e.g. ecr.io/project/image)"
+				}
+
+				if selectedDeploymentOption == DeployOptionKustomize {
+					imageQuestion = "What is the main container image of this project which is deployed by this Kustomization? (e.g. ecr.io/project/image)"
+				}
+
+				image, err = cmd.log.Question(&survey.QuestionOptions{
+					Question:          imageQuestion,
+					ValidationMessage: "Please enter a valid container image from a Kubernetes pod (e.g. myregistry.tld/project/image)",
+					ValidationFunc: func(name string) error {
+						_, _, err := dockerfile.GetStrippedDockerImageName(strings.ToLower(name))
+						return err
+					},
+				})
+				if err != nil {
+					return err
+				}
+			} else {
+				image = imageAnswer
 			}
 		}
 
@@ -371,27 +413,29 @@ func (cmd *InitCmd) initDevspace(f factory.Factory, configLoader loader.ConfigLo
 		}
 	}
 
-	image = config.Images[imageName].Image
-
 	// Determine app port
 	portString := ""
 
-	// Try to get ports from dockerfile
-	ports, err := dockerfile.GetPorts(config.Images[imageName].Dockerfile)
-	if err == nil {
-		if len(ports) == 1 {
-			portString = strconv.Itoa(ports[0])
-		} else if len(ports) > 1 {
-			portString, err = cmd.log.Question(&survey.QuestionOptions{
-				Question:     "Which port is your application listening on?",
-				DefaultValue: strconv.Itoa(ports[0]),
-			})
-			if err != nil {
-				return err
-			}
+	if len(config.Images) > 0 {
+		image = config.Images[imageName].Image
 
-			if portString == "" {
+		// Try to get ports from dockerfile
+		ports, err := dockerfile.GetPorts(config.Images[imageName].Dockerfile)
+		if err == nil {
+			if len(ports) == 1 {
 				portString = strconv.Itoa(ports[0])
+			} else if len(ports) > 1 {
+				portString, err = cmd.log.Question(&survey.QuestionOptions{
+					Question:     "Which port is your application listening on?",
+					DefaultValue: strconv.Itoa(ports[0]),
+				})
+				if err != nil {
+					return err
+				}
+
+				if portString == "" {
+					portString = strconv.Itoa(ports[0])
+				}
 			}
 		}
 	}
@@ -722,7 +766,7 @@ func (cmd *InitCmd) render(f factory.Factory, config *latest.Config) (string, er
 	err := loader.Save(renderPath, config)
 	defer os.Remove(renderPath)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "temp render.yaml")
 	}
 
 	// Use the render command to render it.
@@ -741,8 +785,7 @@ func (cmd *InitCmd) render(f factory.Factory, config *latest.Config) (string, er
 	}
 	err = renderCmd.RunDefault(f)
 	if err != nil {
-		f.GetLog().Debugf("error rendering chart: %v", err)
-		return "", nil
+		return "", errors.Wrap(err, "devspace render")
 	}
 
 	return writer.String(), nil

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+)
+
+type parseImagesTestCase struct {
+	name      string
+	manifests string
+	expected  []string
+}
+
+func TestParseImages(t *testing.T) {
+	testCases := []parseImagesTestCase{
+		{
+			name: `Single`,
+			manifests: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "new"
+  labels:
+    "app.kubernetes.io/name": "devspace-app"
+    "app.kubernetes.io/component": "test"
+    "app.kubernetes.io/managed-by": "Helm"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      "app.kubernetes.io/name": "devspace-app"
+      "app.kubernetes.io/component": "test"
+      "app.kubernetes.io/managed-by": "Helm"
+  template:
+    metadata:
+      labels:
+        "app.kubernetes.io/name": "devspace-app"
+        "app.kubernetes.io/component": "test"
+        "app.kubernetes.io/managed-by": "Helm"
+    spec:
+      containers:
+        - image: "username/app"
+          name: "container-0"
+`,
+			expected: []string{
+				"username/app",
+			},
+		},
+		{
+			name: `Multiple`,
+			manifests: `
+---
+# Source: my-app/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: php
+  labels:
+    release: "test-helm"
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    release: "test-helm"
+---
+# Source: my-app/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-helm
+  labels:
+    release: "test-helm"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      release: "test-helm"
+  template:
+    metadata:
+      annotations:
+        revision: "1"
+      labels:
+        release: "test-helm"
+    spec:
+      containers:
+      - name: default
+        image: "php"
+`,
+			expected: []string{
+				"php",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		manifests := testCase.manifests
+
+		actual, err := parseImages(manifests)
+		assert.NilError(
+			t,
+			err,
+			"Unexpected error in test case %s",
+			testCase.name,
+		)
+
+		expected := testCase.expected
+		assert.Assert(
+			t,
+			cmp.DeepEqual(expected, actual),
+			"Unexpected values in test case %s",
+			testCase.name,
+		)
+	}
+}

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -81,6 +81,7 @@ func (m *manager) AddKubectlDeployment(deploymentName string, isKustomization bo
 	if isKustomization {
 		m.config.Deployments[deploymentName].Kubectl.Kustomize = ptr.Bool(isKustomization)
 	}
+	m.isRemote[deploymentName] = false
 
 	return nil
 }
@@ -147,6 +148,7 @@ func (m *manager) AddHelmDeployment(deploymentName string) error {
 			}
 
 			helmConfig.Chart.Name = localChartPathRel
+			m.isRemote[deploymentName] = false
 		} else if chartLocation == chartRepo || chartLocation == archiveURL {
 		ChartRepoLoop:
 			for {
@@ -249,6 +251,7 @@ func (m *manager) AddHelmDeployment(deploymentName string) error {
 							m.localCache.SetVar(passwordVar, password)
 						}
 
+						m.isRemote[deploymentName] = true
 						break ChartRepoLoop
 					}
 				}
@@ -305,6 +308,7 @@ func (m *manager) AddHelmDeployment(deploymentName string) error {
 					Events:  []string{"before:deploy"},
 				})
 
+				m.isRemote[deploymentName] = true
 				break
 			}
 		}
@@ -360,8 +364,13 @@ func (m *manager) AddComponentDeployment(deploymentName, image string, servicePo
 			Values: chartValues,
 		},
 	}
+	m.isRemote[deploymentName] = true
 
 	return nil
+}
+
+func (m *manager) IsRemoteDeployment(deploymentName string) bool {
+	return m.isRemote[deploymentName]
 }
 
 func chartRepoURL(url string) string {

--- a/pkg/devspace/configure/manager.go
+++ b/pkg/devspace/configure/manager.go
@@ -2,6 +2,7 @@ package configure
 
 import (
 	"context"
+
 	"github.com/loft-sh/devspace/pkg/devspace/config/localcache"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/docker"
@@ -15,6 +16,7 @@ type Manager interface {
 	AddHelmDeployment(deploymentName string) error
 	AddComponentDeployment(deploymentName, image string, servicePort int) error
 	AddImage(imageName, image, projectNamespace, dockerfile string) error
+	IsRemoteDeployment(imageName string) bool
 }
 
 // Factory defines the factory methods needed by the configure manager to create new configuration
@@ -28,6 +30,7 @@ type manager struct {
 	config     *latest.Config
 	localCache localcache.Cache
 	factory    Factory
+	isRemote   map[string]bool
 }
 
 // NewManager creates a new instance of the interface Manager
@@ -37,5 +40,6 @@ func NewManager(factory Factory, config *latest.Config, localCache localcache.Ca
 		factory:    factory,
 		config:     config,
 		localCache: localCache,
+		isRemote:   map[string]bool{},
 	}
 }


### PR DESCRIPTION
### Changes

- Allow the user to manually enter an image or skip if images cannot be found. This does not fix #2104, but provides a "break glass" option when it occurs.
- Improvements to chart repository URL handling
- Add additional question to allow deploy-only use cases instead of assuming there is always an image to develop