### PR TITLE
fixes import URL

### DIFF
--- a/docs/pages/configuration/imports/README.mdx
+++ b/docs/pages/configuration/imports/README.mdx
@@ -17,7 +17,7 @@ Let's say we have a `devspace.yaml` in `project-a` with the following content:
 ```yaml title="File: github.com/project-a/devspace.yaml"
 version: v2beta1
 imports:
-- git: github.com/project-b/devspace.yaml
+- git: github.com/project-b.git
   tag: v1.2.0
 - ...
 functions:
@@ -61,7 +61,7 @@ Let's assume the following `devspace.yaml` inside `project-a`:
 ```yaml title="File: github.com/project-a/devspace.yaml"
 version: v2beta1
 imports:
-- git: github.com/project-b/devspace.yaml
+- git: github.com/project-b.git
 functions:
   function_x: |-
     echo "This is a function_x from project-a"


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

I just tried it and devspace will attempt to clone the repository directly from the URL. So received this error:

```
warn Error cloning or pulling git repository github.com/lianmakesthings/devspace-shared/devspace.yaml: Error running 'git clone github.com/lianmakesthings/devspace-shared/devspace.yaml /Users/lianmakesthings/.devspace/dependencies/github-com-lianmakesthings-devspace-shared-devspace-yaml --depth 1': error executing 'git clone github.com/lianmakesthings/devspace-shared/devspace.yaml /Users/lianmakesthings/.devspace/dependencies/github-com-lianmakesthings-devspace-shared-devspace-yaml --depth 1':  -> fatal: repository 'github.com/lianmakesthings/devspace-shared/devspace.yaml' does not exist
```

Using the full .git URL instead, works. Devspace will try to find the devspace.yaml in the cloned repo.