### PR TITLE
fix: dev containers not being processed in nested format

### DIFF
--- a/pkg/devspace/devpod/devpod.go
+++ b/pkg/devspace/devpod/devpod.go
@@ -528,7 +528,7 @@ func needPodReplace(devPodConfig *latest.DevPod) bool {
 
 	needReplace := false
 	loader.EachDevContainer(devPodConfig, func(devContainer *latest.DevContainer) bool {
-		if needPodReplaceContainer(&devPodConfig.DevContainer) {
+		if needPodReplaceContainer(devContainer) {
 			needReplace = true
 			return false
 		}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
The following replaces the devImage correctly:
```yaml
dev:
  loft:
    labelSelector:
      app: loft
    devImage: loftsh/go
```

However the following format fails to replace the image with the devImage:
```yaml
dev:
  loft:
    labelSelector:
      app: loft
    containers:
      manager:
        devImage: loftsh/go
```


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would not process multiple named dev containers

