### PR TITLE
fix: op patching to not add elements if key already exists

### DIFF
--- a/e2e/tests/config/testdata/patch-add-dont-overwrite-existing-key/devspace.yaml
+++ b/e2e/tests/config/testdata/patch-add-dont-overwrite-existing-key/devspace.yaml
@@ -1,0 +1,16 @@
+version: v1beta11
+images:
+  importme:
+    image: golang:1.17
+    context: ../..
+profiles:
+  - name: deploy
+    patches:
+      - op: add
+        path: images.importme.context
+        value: ../..
+  - name: patch-ok
+    patches:
+      - op: add
+        path: images.importme.rebuildStrategy
+        value: ignoreContextChanges

--- a/pkg/devspace/config/loader/patch/operation.go
+++ b/pkg/devspace/config/loader/patch/operation.go
@@ -2,7 +2,6 @@ package patch
 
 import (
 	"fmt"
-
 	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -35,38 +34,66 @@ func (op *Operation) Perform(doc *yaml.Node) error {
 		return err
 	}
 
-	if len(matches) == 0 {
-		if op.Op == opAdd {
-			matches, err = getParents(doc, op.Path)
-			if err != nil {
-				return fmt.Errorf("could not add using path: %s", op.Path)
-			}
+	if len(matches) == 0 && op.Op != opAdd {
+		return fmt.Errorf("%s operation does not apply: doc is missing path: %s", op.Op, op.Path)
+	}
 
-			parentPath := op.Path.getParentPath()
-			propertName := op.Path.getChildName()
-			if op.Value != nil {
-				propertyValue := op.Value.Content[0]
-				op.Value = createMappingNode(propertName, propertyValue)
+	var f func(parent *yaml.Node, match *yaml.Node)
+
+	switch op.Op {
+	case opAdd:
+		f = op.add
+
+		var pathMatches bool
+
+		if len(matches) > 0 {
+			pathMatches = true
+
+			if matches[0].Kind == yaml.MappingNode || matches[0].Kind == yaml.SequenceNode {
+				break
 			}
-			op.Path = OpPath(parentPath)
-		} else {
-			return fmt.Errorf("%s operation does not apply: doc is missing path: %s", op.Op, op.Path)
 		}
+
+		originalMatches := matches
+
+		matches, err = getParents(doc, op.Path)
+		if err != nil {
+			return fmt.Errorf("could not add using path: %s", op.Path)
+		}
+
+		if len(matches) > 0 && pathMatches {
+			if matches[0].Kind == yaml.SequenceNode {
+				matches = originalMatches
+				break
+			} else {
+				// we are trying to overwrite an existing key in a map, don't do that!
+				return fmt.Errorf(
+					"attempting add operation for non array/object path '%s' which already exists",
+					op.Path,
+				)
+			}
+		}
+
+		parentPath := op.Path.getParentPath()
+		propertyName := op.Path.getChildName()
+		if op.Value != nil {
+			propertyValue := op.Value.Content[0]
+			op.Value = createMappingNode(propertyName, propertyValue)
+		}
+		op.Path = OpPath(parentPath)
+
+	case opRemove:
+		f = op.remove
+	case opReplace:
+		f = op.replace
+	default:
+		return fmt.Errorf("unexpected op: %s", op.Op)
 	}
 
 	for _, match := range matches {
 		parent := find(doc, containsChild(match))
 
-		switch op.Op {
-		case opAdd:
-			op.add(parent, match)
-		case opRemove:
-			op.remove(parent, match)
-		case opReplace:
-			op.replace(parent, match)
-		default:
-			return fmt.Errorf("unexpected op: %s", op.Op)
-		}
+		f(parent, match)
 	}
 
 	return nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
N/A


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace add patch operations on existing keys breaks patching.

**What else do we need to know?** 

This fixes an issue where adding an already existing key to a map would basically append the value in your patch to the key. Unfortunately this would basically shift the yaml around so now the previous value would be the key on the next line. Example: 

```
   importme:
        build:
            buildKit: {}
        context: ../..
        veryimportantpath: dockerfile
        ./Dockerfile: image
        golang:1.17: rebuildStrategy
```

The above output is an example where there was a context set to "veryimportantpath", and an add op setting the context to "../..". This would obviously cause some errors. Moreover subsequent operations may try to reference the key "dockerfile" which is actually no longer a key in the document, causing an exception like `remove operation does not apply: doc is missing path: images.agent.dockerfile`. 

The `Perform` function got a little more complicated than I'd like to account for not breaking the ability to add elements into existing arrays. 