### PR TITLE
fix: sync path parsing for windows

### DIFF
--- a/pkg/devspace/services/sync/controller.go
+++ b/pkg/devspace/services/sync/controller.go
@@ -301,7 +301,10 @@ func ParseSyncPath(path string) (localPath string, remotePath string, err error)
 
 	splitted := strings.Split(path, ":")
 	if len(splitted) > 2 {
-		return "", "", fmt.Errorf("error in sync path %s: should have format local:remote", path)
+		newSplitted := []string{}
+		newSplitted = append(newSplitted, strings.Join(splitted[0:len(splitted)-1], ":"))
+		newSplitted = append(newSplitted, splitted[len(splitted)-1])
+		splitted = newSplitted
 	}
 
 	if len(splitted) == 1 {

--- a/pkg/devspace/services/sync/controller_test.go
+++ b/pkg/devspace/services/sync/controller_test.go
@@ -1,0 +1,32 @@
+package sync
+
+import (
+	"gotest.tools/assert"
+	"testing"
+)
+
+type parseSyncPathTestCase struct {
+	name string
+	in   string
+
+	expectedLocal  string
+	expectedRemote string
+}
+
+func TestParseSyncPath(t *testing.T) {
+	testCases := []parseSyncPathTestCase{
+		{
+			name:           "Test Windows",
+			in:             "C:/codeproject:/home/dev/codeproject",
+			expectedLocal:  "C:/codeproject",
+			expectedRemote: "/home/dev/codeproject",
+		},
+	}
+
+	for _, testCase := range testCases {
+		local, remote, err := ParseSyncPath(testCase.in)
+		assert.NilError(t, err)
+		assert.Equal(t, local, testCase.expectedLocal, "Expect local path in "+testCase.name)
+		assert.Equal(t, remote, testCase.expectedRemote, "Expect remote path in "+testCase.name)
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2221


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would not parse absolute paths on windows correctly