### PR TITLE
Adding examples for built-in function flags

### DIFF
--- a/docs/pages/configuration/_partials/functions/build_images.mdx
+++ b/docs/pages/configuration/_partials/functions/build_images.mdx
@@ -11,6 +11,7 @@ import PartialSet from "./build_images/set.mdx"
 import PartialSetstring from "./build_images/set-string.mdx"
 import PartialFrom from "./build_images/from.mdx"
 import PartialFromfile from "./build_images/from-file.mdx"
+import PartialExample from "./build_images/example.mdx"
 
 <details className="config-field -function" data-expandable="true">
 <summary>
@@ -33,6 +34,7 @@ Builds all images passed as arguments in parallel
 <PartialSetstring />
 <PartialFrom />
 <PartialFromfile />
+<PartialExample />
 
 
 </details>

--- a/docs/pages/configuration/_partials/functions/build_images/example.mdx
+++ b/docs/pages/configuration/_partials/functions/build_images/example.mdx
@@ -3,18 +3,30 @@
 ```yaml
 images:
   myImage:
-    dockerfile: ./Dockerfile
+    image: registry.path.to.image
+    context: ./
 
 pipelines:
   build: |-
-     echo "Welcome to your custom build pipeline!"
+    echo "Welcome to your custom build pipeline!"
 
-     # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
-     build_images myImage --set dockerfile=./Dockerfile.dev --set-string key1=value1
+    # Exchange image config values here
+    build_images myImage --set "dockerfile=./Dockerfile"
+
+    # Use --set-string to force a field to be a string
+    build_images myImage --set-string "myImage.image=true"
     
-     # Use --from to create a new config based on an existing config
-     build_images myOtherImage --from myImage --set context=../
+    # Use --from to create a new config based on an existing config
+    build_images myOtherImage --from myImage
 
-     # Use --from-file when you want to load the config for the image from a file
-     build_images myFileImage --from-file image.yaml
+    # Creating a sample images config yaml
+    echo """
+    newImage:
+      image: registry.path.to.image
+      dockerfile: ./new/Dockerfile
+      context: ./new
+    """ > ${DEVSPACE_TMPDIR}/new-image.yaml
+
+    # Use --from-file when you want to load the config for the image from a file
+    build_images imageFromFile --from-file new-image.yaml
 ```

--- a/docs/pages/configuration/_partials/functions/build_images/example.mdx
+++ b/docs/pages/configuration/_partials/functions/build_images/example.mdx
@@ -1,0 +1,20 @@
+#### Example:
+
+```yaml
+images:
+  myImage:
+    dockerfile: ./Dockerfile
+
+pipelines:
+  build: |-
+     echo "Welcome to your custom build pipeline!"
+
+     # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     build_images myImage --set dockerfile=./Dockerfile.dev --set-string key1=value1
+    
+     # Use --from to create a new config based on an existing config
+     build_images myOtherImage --from myImage --set context=../
+
+     # Use --from-file when you want to load the config for the image from a file
+     build_images myFileImage --from-file image.yaml
+```

--- a/docs/pages/configuration/_partials/functions/create_deployments.mdx
+++ b/docs/pages/configuration/_partials/functions/create_deployments.mdx
@@ -8,6 +8,7 @@ import PartialSetstring from "./create_deployments/set-string.mdx"
 import PartialFrom from "./create_deployments/from.mdx"
 import PartialFromfile from "./create_deployments/from-file.mdx"
 import PartialAll from "./create_deployments/all.mdx"
+import PartialExample from "./create_deployments/example.mdx"
 
 <details className="config-field -function" data-expandable="true">
 <summary>
@@ -27,6 +28,6 @@ Creates all deployments passed as arguments in parallel
 <PartialFrom />
 <PartialFromfile />
 <PartialAll />
-
+<PartialExample />
 
 </details>

--- a/docs/pages/configuration/_partials/functions/create_deployments/example.mdx
+++ b/docs/pages/configuration/_partials/functions/create_deployments/example.mdx
@@ -1,20 +1,16 @@
 #### Example:
 
 ```yaml
-images:
-  myImage:
-    dockerfile: ./Dockerfile
-
 pipelines:
   create: |-
      echo "Welcome to your custom create pipeline!"
 
-     # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
-     create_deployments myImage --set dockerfile=./Dockerfile.dev --set-string key1=value1
+     # Exchange deployment image here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     create_deployments myDeployment --set myDeployment.myImageField=myImage --set-string key1=value1
     
      # Use --from to create a new config based on an existing config
-     create_deployments myOtherImage --from myImage --set context=../
+     create_deployments myDeployment --from myDeployment2:myImage
 
      # Use --from-file when you want to load the config for the image from a file
-     create_deployments myFileImage --from-file image.yaml
+     create_deployments myFileImage --from-file myDeployment.yaml
 ```

--- a/docs/pages/configuration/_partials/functions/create_deployments/example.mdx
+++ b/docs/pages/configuration/_partials/functions/create_deployments/example.mdx
@@ -1,0 +1,20 @@
+#### Example:
+
+```yaml
+images:
+  myImage:
+    dockerfile: ./Dockerfile
+
+pipelines:
+  create: |-
+     echo "Welcome to your custom create pipeline!"
+
+     # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     create_deployments myImage --set dockerfile=./Dockerfile.dev --set-string key1=value1
+    
+     # Use --from to create a new config based on an existing config
+     create_deployments myOtherImage --from myImage --set context=../
+
+     # Use --from-file when you want to load the config for the image from a file
+     create_deployments myFileImage --from-file image.yaml
+```

--- a/docs/pages/configuration/_partials/functions/create_deployments/example.mdx
+++ b/docs/pages/configuration/_partials/functions/create_deployments/example.mdx
@@ -1,16 +1,35 @@
 #### Example:
 
 ```yaml
+deployments:
+  test:
+    helm:
+      values:
+        containers:
+        - image: nginx
+
 pipelines:
-  create: |-
-     echo "Welcome to your custom create pipeline!"
+  deploy: |-
 
-     # Exchange deployment here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
-     create_deployments myDeployment --set myDeployment.myImageField=myImage --set-string key1=value1
-    
-     # Use --from to create a new config based on an existing config
-     create_deployments myDeployment --from myDeployment2:myImage
+    # Exchange the image in our deployment with --set
+    create_deployments test --set "helm.values.containers[0].image=bitnami/nginx"
 
-     # Use --from-file when you want to load the config for the image from a file
-     create_deployments myFileImage --from-file myDeployment.yaml
-```
+    # Create a new deployment based on another deployment with --from
+    # This will copy over the values from the test deployment
+    create_deployments nginx --from test 
+
+    # Create a new deployment from a file. 
+    # ${DEVSPACE_TMPDIR} is always cleaned up after each run
+    echo """
+    helm:
+      values:
+        containers:
+        - image: nginx
+    """ > ${DEVSPACE_TMPDIR}/my-deployment.yaml
+
+    # Create a new deployment based on config info from my-deployment.yaml
+    create_deployments nginx-from-file --from-file ${DEVSPACE_TMPDIR}/my-deployment.yaml
+
+    # Force the container name to be a string
+    create_deployments nginx-string-annotation --from test \
+                                               --set-string "helm.values.containers[0].name=true"

--- a/docs/pages/configuration/_partials/functions/create_deployments/example.mdx
+++ b/docs/pages/configuration/_partials/functions/create_deployments/example.mdx
@@ -5,7 +5,7 @@ pipelines:
   create: |-
      echo "Welcome to your custom create pipeline!"
 
-     # Exchange deployment image here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     # Exchange deployment here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
      create_deployments myDeployment --set myDeployment.myImageField=myImage --set-string key1=value1
     
      # Use --from to create a new config based on an existing config

--- a/docs/pages/configuration/_partials/functions/ensure_pull_secrets.mdx
+++ b/docs/pages/configuration/_partials/functions/ensure_pull_secrets.mdx
@@ -4,6 +4,7 @@ import PartialSetstring from "./ensure_pull_secrets/set-string.mdx"
 import PartialFrom from "./ensure_pull_secrets/from.mdx"
 import PartialFromfile from "./ensure_pull_secrets/from-file.mdx"
 import PartialAll from "./ensure_pull_secrets/all.mdx"
+import PartialExample from "./ensure_pull_secrets/example.mdx"
 
 <details className="config-field -function" data-expandable="true">
 <summary>
@@ -19,6 +20,6 @@ Creates pull secrets for all images passed as arguments
 <PartialFrom />
 <PartialFromfile />
 <PartialAll />
-
+<PartialExample />
 
 </details>

--- a/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
+++ b/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
@@ -11,18 +11,18 @@ pullSecrets:
 
 pipelines:
   pull_secrets: |-
-     echo "Welcome to your custom pull secrets pipeline!"
+    echo "Welcome to your custom pull secrets pipeline!"
 
-     # Exchange pull secret config with --set
-     # Change the pull secret name with "new-pullsecret-name"
-     ensure_pull_secrets my-pullsecret --set "my-pullsecret.secret=new-pullsecret-name"
+    # Exchange pull secret config with --set
+    # Change the pull secret name with "new-pullsecret-name"
+    ensure_pull_secrets my-pullsecret --set "my-pullsecret.secret=new-pullsecret-name"
     
     # Use --from to create a new config based on an existing config
     # Use --set-string to force a field to be a string
     # Ensure the registry field is a string
-     ensure_pull_secrets new-pullSecret --from my-pullsecret --set-string "my-pullsecret.registry=true"
+    ensure_pull_secrets new-pullSecret --from my-pullsecret --set-string "my-pullsecret.registry=true"
 
-    # Creating a sample yaml file with pullsecret config info
+    # Creating a sample yaml file with pull secret config info
     echo """
     registry: my-registry.com:5000
     secret: my-pull-secret-name
@@ -31,7 +31,7 @@ pipelines:
       - my-other-service-account
     """ > ${DEVSPACE_TMPDIR}/my-pullsecret-config.yaml
 
-     # Use --from-file when you want to load the config for the image from a file
-     # Create myPullSecret with config info from the newly created my-pullsecret-config.yaml
-     ensure_pull_secrets myPullSecret --from-file my-pullsecret-config.yaml
+    # Use --from-file when you want to load the config for the image from a file
+    # Create myPullSecret with config info from the newly created my-pullsecret-config.yaml
+    ensure_pull_secrets myPullSecret --from-file my-pullsecret-config.yaml
 ```

--- a/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
+++ b/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
@@ -10,11 +10,11 @@ pipelines:
      echo "Welcome to your custom pull_secrets pipeline!"
 
      # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
-     pull_secrets myImage --set dockerfile=./Dockerfile.dev --set-string key1=value1
+     ensure_pull_secrets myPullSecret --set dockerfile=./Dockerfile.dev --set-string key1=value1
     
      # Use --from to create a new config based on an existing config
-     pull_secrets myOtherImage --from myImage --set context=../
+     ensure_pull_secrets myPullSecret --from myImage
 
      # Use --from-file when you want to load the config for the image from a file
-     pull_secrets myFileImage --from-file image.yaml
+     ensure_pull_secrets myPullSecret --from-file image.yaml
 ```

--- a/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
+++ b/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
@@ -1,0 +1,20 @@
+#### Example:
+
+```yaml
+images:
+  myImage:
+    dockerfile: ./Dockerfile
+
+pipelines:
+  pull_secrets: |-
+     echo "Welcome to your custom pull_secrets pipeline!"
+
+     # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     pull_secrets myImage --set dockerfile=./Dockerfile.dev --set-string key1=value1
+    
+     # Use --from to create a new config based on an existing config
+     pull_secrets myOtherImage --from myImage --set context=../
+
+     # Use --from-file when you want to load the config for the image from a file
+     pull_secrets myFileImage --from-file image.yaml
+```

--- a/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
+++ b/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
@@ -1,20 +1,37 @@
 #### Example:
 
 ```yaml
-images:
-  myImage:
-    dockerfile: ./Dockerfile
+pullSecrets:
+  my-pullsecret:
+    registry: my-registry.com:5000
+    secret: my-pull-secret-name
+    serviceAccounts:
+      - default
+      - my-other-service-account
 
 pipelines:
   pull_secrets: |-
-     echo "Welcome to your custom pull_secrets pipeline!"
+     echo "Welcome to your custom pull secrets pipeline!"
 
-     # Exchange pull secrets here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
-     ensure_pull_secrets myPullSecret --set dockerfile=./Dockerfile.dev --set-string key1=value1
+     # Exchange pull secret config with --set
+     # Change the pull secret name with "new-pullsecret-name"
+     ensure_pull_secrets my-pullsecret --set "my-pullsecret.secret=new-pullsecret-name"
     
-     # Use --from to create a new config based on an existing config
-     ensure_pull_secrets myPullSecret --from myImage
+    # Use --from to create a new config based on an existing config
+    # Use --set-string to force a field to be a string
+    # Ensure the registry field is a string
+     ensure_pull_secrets new-pullSecret --from my-pullsecret --set-string "my-pullsecret.registry=true"
+
+    # Creating a sample yaml file with pullsecret config info
+    echo """
+    registry: my-registry.com:5000
+    secret: my-pull-secret-name
+    serviceAccounts:
+      - default
+      - my-other-service-account
+    """ > ${DEVSPACE_TMPDIR}/my-pullsecret-config.yaml
 
      # Use --from-file when you want to load the config for the image from a file
-     ensure_pull_secrets myPullSecret --from-file image.yaml
+     # Create myPullSecret with config info from the newly created my-pullsecret-config.yaml
+     ensure_pull_secrets myPullSecret --from-file my-pullsecret-config.yaml
 ```

--- a/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
+++ b/docs/pages/configuration/_partials/functions/ensure_pull_secrets/example.mdx
@@ -9,7 +9,7 @@ pipelines:
   pull_secrets: |-
      echo "Welcome to your custom pull_secrets pipeline!"
 
-     # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     # Exchange pull secrets here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
      ensure_pull_secrets myPullSecret --set dockerfile=./Dockerfile.dev --set-string key1=value1
     
      # Use --from to create a new config based on an existing config

--- a/docs/pages/configuration/_partials/functions/start_dev.mdx
+++ b/docs/pages/configuration/_partials/functions/start_dev.mdx
@@ -9,6 +9,7 @@ import PartialSetstring from "./start_dev/set-string.mdx"
 import PartialFrom from "./start_dev/from.mdx"
 import PartialFromfile from "./start_dev/from-file.mdx"
 import PartialAll from "./start_dev/all.mdx"
+import PartialExample from "./start_dev/example.mdx"
 
 <details className="config-field -function" data-expandable="true">
 <summary>
@@ -29,6 +30,6 @@ Starts all dev modes passed as arguments
 <PartialFrom />
 <PartialFromfile />
 <PartialAll />
-
+<PartialExample />
 
 </details>

--- a/docs/pages/configuration/_partials/functions/start_dev/example.mdx
+++ b/docs/pages/configuration/_partials/functions/start_dev/example.mdx
@@ -9,15 +9,15 @@ dev:
 
 pipelines:
   test: |-
-     echo "Welcome to your custom pipeline!"
+    echo "Welcome to your custom pipeline!"
 
-     # Exchange default dev config here
-     # Run test-dev config above and set the port to 3000
-     start_dev test-dev --set "ports.imageName.forward[0]=3000"
+    # Exchange default dev config here
+    # Run test-dev config above and set the port to 3000
+    start_dev test-dev --set "ports.imageName.forward[0]=3000"
     
-     # Use --from to create a new config based on an existing config
-     # Create a new dev config from test-dev above, and ensure the imageName is a string
-     start_dev newDevConfig --from test-dev --set-string "ports.imageName=true"
+    # Use --from to create a new config based on an existing config
+    # Create a new dev config from test-dev above, and ensure the imageName is a string
+    start_dev newDevConfig --from test-dev --set-string "ports.imageName=true"
 
     # Creating a sample yaml file with dev config info
     echo """
@@ -27,7 +27,7 @@ pipelines:
       - port: 8080
     """ > ${DEVSPACE_TMPDIR}/my-dev-config.yaml
 
-     # Use --from-file when you want to load the config for the image from a file
-     # Create a new dev config from the newly created my-dev-config.yaml
-     start_dev newDevConfig --from-file ${DEVSPACE_TMPDIR}/my-dev-config.yaml
+    # Use --from-file when you want to load the config for the image from a file
+    # Create a new dev config from the newly created my-dev-config.yaml
+    start_dev newDevConfig --from-file ${DEVSPACE_TMPDIR}/my-dev-config.yaml
 ```

--- a/docs/pages/configuration/_partials/functions/start_dev/example.mdx
+++ b/docs/pages/configuration/_partials/functions/start_dev/example.mdx
@@ -1,0 +1,20 @@
+#### Example:
+
+```yaml
+images:
+  myImage:
+    dockerfile: ./Dockerfile
+
+pipelines:
+  dev: |-
+     echo "Welcome to your custom dev pipeline!"
+
+     # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     start_dev myImage --set dockerfile=./Dockerfile.dev --set-string key1=value1
+    
+     # Use --from to create a new config based on an existing config
+     start_dev myOtherImage --from myImage --set context=../
+
+     # Use --from-file when you want to load the config for the image from a file
+     start_dev myFileImage --from-file image.yaml
+```

--- a/docs/pages/configuration/_partials/functions/start_dev/example.mdx
+++ b/docs/pages/configuration/_partials/functions/start_dev/example.mdx
@@ -1,16 +1,33 @@
 #### Example:
 
 ```yaml
-pipelines:
-  dev: |-
-     echo "Welcome to your custom dev pipeline!"
+dev:
+  ports:
+  - imageName: test-dev
+    forward:
+    - port: 8080
 
-     # Exchange dev config here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
-     start_dev myDevConfig --set myConfigField=value --set-string key1=value1
+pipelines:
+  test: |-
+     echo "Welcome to your custom pipeline!"
+
+     # Exchange default dev config here
+     # Run test-dev config above and set the port to 3000
+     start_dev test-dev --set "ports.imageName.forward[0]=3000"
     
      # Use --from to create a new config based on an existing config
-     start_dev myOtherDevConfig --from myDevConfig
+     # Create a new dev config from test-dev above, and ensure the imageName is a string
+     start_dev newDevConfig --from test-dev --set-string "ports.imageName=true"
+
+    # Creating a sample yaml file with dev config info
+    echo """
+    ports:
+    - imageName: test-dev
+      forward:
+      - port: 8080
+    """ > ${DEVSPACE_TMPDIR}/my-dev-config.yaml
 
      # Use --from-file when you want to load the config for the image from a file
-     start_dev myDevConfig --from-file myDevConfig.yaml
+     # Create a new dev config from the newly created my-dev-config.yaml
+     start_dev newDevConfig --from-file ${DEVSPACE_TMPDIR}/my-dev-config.yaml
 ```

--- a/docs/pages/configuration/_partials/functions/start_dev/example.mdx
+++ b/docs/pages/configuration/_partials/functions/start_dev/example.mdx
@@ -1,20 +1,17 @@
 #### Example:
 
 ```yaml
-images:
-  myImage:
-    dockerfile: ./Dockerfile
 
 pipelines:
   dev: |-
      echo "Welcome to your custom dev pipeline!"
 
-     # Exchange Dockerfile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
-     start_dev myImage --set dockerfile=./Dockerfile.dev --set-string key1=value1
+     # Exchange dev profile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     start_dev myDevConfig --set myConfigField=value --set-string key1=value1
     
      # Use --from to create a new config based on an existing config
-     start_dev myOtherImage --from myImage --set context=../
+     start_dev myOtherDevConfig --from myDevConfig
 
      # Use --from-file when you want to load the config for the image from a file
-     start_dev myFileImage --from-file image.yaml
+     start_dev myDevConfig --from-file myDevConfigMap.yaml
 ```

--- a/docs/pages/configuration/_partials/functions/start_dev/example.mdx
+++ b/docs/pages/configuration/_partials/functions/start_dev/example.mdx
@@ -1,17 +1,16 @@
 #### Example:
 
 ```yaml
-
 pipelines:
   dev: |-
      echo "Welcome to your custom dev pipeline!"
 
-     # Exchange dev profile here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
+     # Exchange dev config here (use --set-string if you want to force the field to be a string e.g. when setting labels to "true")
      start_dev myDevConfig --set myConfigField=value --set-string key1=value1
     
      # Use --from to create a new config based on an existing config
      start_dev myOtherDevConfig --from myDevConfig
 
      # Use --from-file when you want to load the config for the image from a file
-     start_dev myDevConfig --from-file myDevConfigMap.yaml
+     start_dev myDevConfig --from-file myDevConfig.yaml
 ```


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind documentation

**What does this pull request do? Which issues does it resolve?**

Resolves #2220 
Adds example YAML to built-in functions `build_images`, `create_deployments`, `ensure_pull_secrets`, and `start_dev`

**Please provide a short message that should be published in the DevSpace release notes**
Added documentation examples for built-in pipeline functions in the config reference
