### PR TITLE
fix: supply helm registry for oci login

### DIFF
--- a/pkg/devspace/helm/v3/client.go
+++ b/pkg/devspace/helm/v3/client.go
@@ -83,8 +83,6 @@ func (c *client) InstallChart(ctx devspacecontext.Context, releaseName string, r
 					return nil, errors.Wrap(err, "chartName malformed for oci registry")
 				}
 
-				ctx.Log().Infof("registry hostname: %v", chartNameUrl.Hostname())
-
 				_, err = c.genericHelm.Exec(ctx, []string{"registry", "login", chartNameUrl.Hostname(), "--username", helmConfig.Chart.Username, "--password", helmConfig.Chart.Password})
 				if err != nil {
 					return nil, errors.Wrap(err, "login oci registry")


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes v6.0.0-beta.0 issue where helm registry login for OCI charts did not supply target registry.


**Please provide a short message that should be published in the DevSpace release notes**
Fixed missing `registry` argument for `helm registry login`


**What else do we need to know?** 
I'm not a Go developer, so have mercy.
