### PR TITLE
fix: use chart directory to detect chart changes

### DIFF
--- a/pkg/devspace/deploy/deployer/helm/deploy.go
+++ b/pkg/devspace/deploy/deployer/helm/deploy.go
@@ -59,7 +59,10 @@ func (d *DeployConfig) Deploy(ctx devspacecontext.Context, forceDeploy bool) (bo
 		chartPath = ctx.ResolvePath(chartPath)
 
 		// Check if the chart directory has changed
-		hash, err = hashpkg.Directory(chartPath)
+		hash, err = hashpkg.DirectoryExcludes(chartPath, []string{
+			".git/",
+			".devspace/",
+		}, true)
 		if err != nil {
 			return false, errors.Errorf("Error hashing chart directory: %v", err)
 		}

--- a/pkg/devspace/deploy/deployer/helm/deploy.go
+++ b/pkg/devspace/deploy/deployer/helm/deploy.go
@@ -2,10 +2,11 @@ package helm
 
 import (
 	"fmt"
-	"github.com/loft-sh/devspace/pkg/devspace/config/versions"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/legacy"
 	runtimevar "github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/runtime"
@@ -42,6 +43,14 @@ func (d *DeployConfig) Deploy(ctx devspacecontext.Context, forceDeploy bool) (bo
 	releaseNamespace := ctx.KubeClient().Namespace()
 	if d.DeploymentConfig.Namespace != "" {
 		releaseNamespace = d.DeploymentConfig.Namespace
+	}
+
+	if d.DeploymentConfig.Helm.Chart.Source != nil {
+		downloadPath, err := d.Helm.DownloadChart(ctx, d.DeploymentConfig.Helm)
+		if err != nil {
+			return false, errors.Wrap(err, "download chart")
+		}
+		chartPath = downloadPath
 	}
 
 	// Hash the chart directory if there is any

--- a/pkg/devspace/helm/testing/client.go
+++ b/pkg/devspace/helm/testing/client.go
@@ -15,6 +15,10 @@ type Client struct {
 	Releases []*types.Release
 }
 
+func (f *Client) DownloadChart(ctx devspacecontext.Context, helmConfig *latest.HelmConfig) (string, error) {
+	return "", nil
+}
+
 // UpdateRepos implements interface
 func (f *Client) UpdateRepos() error {
 	return nil

--- a/pkg/devspace/helm/types/interface.go
+++ b/pkg/devspace/helm/types/interface.go
@@ -7,6 +7,7 @@ import (
 
 // Client is the client interface for helm
 type Client interface {
+	DownloadChart(ctx devspacecontext.Context, helmConfig *latest.HelmConfig) (string, error)
 	InstallChart(ctx devspacecontext.Context, releaseName string, releaseNamespace string, values map[string]interface{}, helmConfig *latest.HelmConfig) (*Release, error)
 	Template(ctx devspacecontext.Context, releaseName, releaseNamespace string, values map[string]interface{}, helmConfig *latest.HelmConfig) (string, error)
 	DeleteRelease(ctx devspacecontext.Context, releaseName string, releaseNamespace string) error

--- a/pkg/devspace/helm/v3/client.go
+++ b/pkg/devspace/helm/v3/client.go
@@ -65,11 +65,12 @@ func (c *client) InstallChart(ctx devspacecontext.Context, releaseName string, r
 	// Chart settings
 	chartName := ""
 	if helmConfig.Chart.Source != nil {
-		chartName, err = c.DownloadChart(ctx, helmConfig)
+		chartName, err = dependencyutil.GetDependencyPath(ctx.WorkingDir(), helmConfig.Chart.Source)
 		if err != nil {
 			return nil, err
 		}
 
+		chartName = filepath.Dir(chartName)
 		args = append(args, chartName)
 	} else {
 		var chartRepo string

--- a/pkg/util/hash/hash.go
+++ b/pkg/util/hash/hash.go
@@ -73,7 +73,6 @@ func Directory(path string) (string, error) {
 
 		return nil
 	})
-
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
When using a helm chart with no name, the current directory is used to detect chart changes. If the current directory contains the `.devspace` folder, it will always detect changes and redeploy the application. This issue presented when using a git repository chart source in a dependency.


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would always re-deploy charts imported using git.