### PR TITLE
fix: download once during render / deploy --render

### DIFF
--- a/pkg/devspace/deploy/deployer/helm/render.go
+++ b/pkg/devspace/deploy/deployer/helm/render.go
@@ -1,8 +1,10 @@
 package helm
 
 import (
-	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
 	"io"
+
+	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
+	"github.com/pkg/errors"
 )
 
 // Render runs a `helm template`
@@ -10,6 +12,13 @@ func (d *DeployConfig) Render(ctx devspacecontext.Context, out io.Writer) error 
 	_, deployValues, err := d.getDeploymentValues(ctx)
 	if err != nil {
 		return err
+	}
+
+	if d.DeploymentConfig.Helm.Chart.Source != nil {
+		_, err := d.Helm.DownloadChart(ctx, d.DeploymentConfig.Helm)
+		if err != nil {
+			return errors.Wrap(err, "download chart")
+		}
 	}
 
 	_, err = d.internalDeploy(ctx, deployValues, out)

--- a/pkg/devspace/helm/v3/client.go
+++ b/pkg/devspace/helm/v3/client.go
@@ -166,11 +166,12 @@ func (c *client) Template(ctx devspacecontext.Context, releaseName, releaseNames
 	// Chart settings
 	chartName := ""
 	if helmConfig.Chart.Source != nil {
-		chartName, err = c.DownloadChart(ctx, helmConfig)
+		chartName, err = dependencyutil.GetDependencyPath(ctx.WorkingDir(), helmConfig.Chart.Source)
 		if err != nil {
 			return "", err
 		}
 
+		chartName = filepath.Dir(chartName)
 		args = append(args, chartName)
 	} else {
 		var chartRepo string


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** 
Prevent downloading helm charts twice for `devspace render` / `devspace deploy --render`


**Please provide a short message that should be published in the DevSpace release notes**
Prevent downloading helm charts twice for `devspace render` / `devspace deploy --render`

**What else do we need to know?** 
