### PR TITLE
devspace enter fixes, wait_pod & resolve vars in imports section

### DIFF
--- a/cmd/enter.go
+++ b/cmd/enter.go
@@ -30,6 +30,7 @@ type EnterCmd struct {
 	Container     string
 	Pod           string
 	Pick          bool
+	TTY           bool
 	Wait          bool
 	Reconnect     bool
 	Screen        bool
@@ -78,6 +79,7 @@ devspace enter bash --image-selector "${runtime.images.app.image}:${runtime.imag
 	enterCmd.Flags().StringVar(&cmd.ImageSelector, "image-selector", "", "The image to search a pod for (e.g. nginx, nginx:latest, ${runtime.images.app}, nginx:${runtime.images.app.tag})")
 	enterCmd.Flags().StringVar(&cmd.WorkingDirectory, "workdir", "", "The working directory where to open the terminal or execute the command")
 
+	enterCmd.Flags().BoolVar(&cmd.TTY, "tty", true, "If to use a tty to start the command")
 	enterCmd.Flags().BoolVar(&cmd.Pick, "pick", true, "Select a pod / container if multiple are found")
 	enterCmd.Flags().BoolVar(&cmd.Wait, "wait", false, "Wait for the pod(s) to start if they are not running")
 	enterCmd.Flags().BoolVar(&cmd.Reconnect, "reconnect", false, "Will reconnect the terminal if an unexpected return code is encountered")
@@ -158,7 +160,7 @@ func (cmd *EnterCmd) Run(f factory.Factory, args []string) error {
 
 	// Start terminal
 	stdout, stderr, stdin := defaultStdStreams(cmd.Stdout, cmd.Stderr, cmd.Stdin)
-	exitCode, err := terminal.StartTerminalFromCMD(ctx, targetselector.NewTargetSelector(selectorOptions), command, cmd.Wait, cmd.Reconnect, cmd.Screen, cmd.ScreenSession, stdout, stderr, stdin)
+	exitCode, err := terminal.StartTerminalFromCMD(ctx, targetselector.NewTargetSelector(selectorOptions), command, cmd.Wait, cmd.Reconnect, cmd.TTY, cmd.Screen, cmd.ScreenSession, stdout, stderr, stdin)
 	if err != nil {
 		return err
 	} else if exitCode != 0 {

--- a/devspace-schema.json
+++ b/devspace-schema.json
@@ -1813,6 +1813,10 @@
         "disableScreen": {
           "type": "boolean",
           "description": "DisableScreen will disable screen which is used by DevSpace by default to preserve\nsessions if connections interrupt or the session is lost."
+        },
+        "disableTTY": {
+          "type": "boolean",
+          "description": "DisableTTY will disable a tty shell for terminal command execution"
         }
       },
       "type": "object",

--- a/docs/hack/functions/main.go
+++ b/docs/hack/functions/main.go
@@ -364,6 +364,14 @@ var Functions = []Function{
 		Group:       groupOther,
 	},
 	{
+		Name:        "wait_pod",
+		Description: "Waits for a pod to become running",
+		Args:        `[command]`,
+		Handler:     commands.WaitPod,
+		Flags:       commands.WaitPodOptions{},
+		Group:       groupOther,
+	},
+	{
 		Name:        "exec_container",
 		Description: `Executes the command provided as argument inside a container`,
 		Args:        `[command]`,

--- a/docs/pages/configuration/_partials/functions/group_other.mdx
+++ b/docs/pages/configuration/_partials/functions/group_other.mdx
@@ -9,9 +9,11 @@ import PartialGetflag from "./get_flag.mdx"
 import PartialCat from "./cat.mdx"
 import PartialGetconfigvalue from "./get_config_value.mdx"
 import PartialExeccontainer from "./exec_container.mdx"
+import PartialWaitpod from "./wait_pod.mdx"
 import PartialSelectpod from "./select_pod.mdx"
 
 <PartialSelectpod />
+<PartialWaitpod />
 <PartialExeccontainer />
 <PartialGetconfigvalue />
 <PartialCat />

--- a/docs/pages/configuration/_partials/functions/group_other_pipeline.mdx
+++ b/docs/pages/configuration/_partials/functions/group_other_pipeline.mdx
@@ -4,9 +4,11 @@
 
 import PartialGetconfigvalue from "./get_config_value.mdx"
 import PartialExeccontainer from "./exec_container.mdx"
+import PartialWaitpod from "./wait_pod.mdx"
 import PartialSelectpod from "./select_pod.mdx"
 
 <PartialSelectpod />
+<PartialWaitpod />
 <PartialExeccontainer />
 <PartialGetconfigvalue />
 

--- a/docs/pages/configuration/_partials/functions/wait_pod.mdx
+++ b/docs/pages/configuration/_partials/functions/wait_pod.mdx
@@ -1,0 +1,26 @@
+
+import PartialImageselector from "./wait_pod/image-selector.mdx"
+import PartialLabelselector from "./wait_pod/label-selector.mdx"
+import PartialContainer from "./wait_pod/container.mdx"
+import PartialNamespace from "./wait_pod/namespace.mdx"
+import PartialDisablewait from "./wait_pod/disable-wait.mdx"
+import PartialTimeout from "./wait_pod/timeout.mdx"
+
+<details className="config-field -function" data-expandable="true">
+<summary>
+
+### `wait_pod` <span className="config-field-type">[command]</span> <span className="config-field-enum"></span> <span className="config-field-default -return"></span> <span className="config-field-required" data-required="true">pipeline only</span>  {#wait_pod}
+
+Waits for a pod to become running
+
+</summary>
+
+<PartialImageselector />
+<PartialLabelselector />
+<PartialContainer />
+<PartialNamespace />
+<PartialDisablewait />
+<PartialTimeout />
+
+
+</details>

--- a/docs/pages/configuration/_partials/functions/wait_pod/container.mdx
+++ b/docs/pages/configuration/_partials/functions/wait_pod/container.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field -function" data-expandable="false">
+<summary>
+
+#### `--container` <span className="config-field-type">string</span> <span className="config-field-enum"></span> <span className="config-field-default -return"></span> <span className="config-field-required" data-required="false">pipeline only</span>  {#wait_pod-container}
+
+The container to use
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/functions/wait_pod/disable-wait.mdx
+++ b/docs/pages/configuration/_partials/functions/wait_pod/disable-wait.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field -function" data-expandable="false">
+<summary>
+
+#### `--disable-wait` <span className="config-field-type">bool</span> <span className="config-field-enum"></span> <span className="config-field-default -return"></span> <span className="config-field-required" data-required="false">pipeline only</span>  {#wait_pod-disable-wait}
+
+If true, will not wait for the container to become ready
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/functions/wait_pod/image-selector.mdx
+++ b/docs/pages/configuration/_partials/functions/wait_pod/image-selector.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field -function" data-expandable="false">
+<summary>
+
+#### `--image-selector` <span className="config-field-type">string</span> <span className="config-field-enum"></span> <span className="config-field-default -return"></span> <span className="config-field-required" data-required="false">pipeline only</span>  {#wait_pod-image-selector}
+
+The image selector to use to select the container
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/functions/wait_pod/label-selector.mdx
+++ b/docs/pages/configuration/_partials/functions/wait_pod/label-selector.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field -function" data-expandable="false">
+<summary>
+
+#### `--label-selector` <span className="config-field-type">string</span> <span className="config-field-enum"></span> <span className="config-field-default -return"></span> <span className="config-field-required" data-required="false">pipeline only</span>  {#wait_pod-label-selector}
+
+The label selector to use to select the container
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/functions/wait_pod/namespace.mdx
+++ b/docs/pages/configuration/_partials/functions/wait_pod/namespace.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field -function" data-expandable="false">
+<summary>
+
+#### `--namespace / -n` <span className="config-field-type">string</span> <span className="config-field-enum"></span> <span className="config-field-default -return"></span> <span className="config-field-required" data-required="false">pipeline only</span>  {#wait_pod-namespace}
+
+The namespace to use
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/functions/wait_pod/timeout.mdx
+++ b/docs/pages/configuration/_partials/functions/wait_pod/timeout.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field -function" data-expandable="false">
+<summary>
+
+#### `--timeout` <span className="config-field-type">int64</span> <span className="config-field-enum"></span> <span className="config-field-default -return"></span> <span className="config-field-required" data-required="false">pipeline only</span>  {#wait_pod-timeout}
+
+The timeout to wait. Defaults to 5 minutes
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/dev/containers/terminal/disableTTY.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/containers/terminal/disableTTY.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `disableTTY` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#dev-containers-terminal-disableTTY}
+
+DisableTTY will disable a tty shell for terminal command execution
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/dev/containers/terminal_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/containers/terminal_reference.mdx
@@ -4,6 +4,7 @@ import PartialWorkDir from "./terminal/workDir.mdx"
 import PartialEnabled from "./terminal/enabled.mdx"
 import PartialDisableReplace from "./terminal/disableReplace.mdx"
 import PartialDisableScreen from "./terminal/disableScreen.mdx"
+import PartialDisableTTY from "./terminal/disableTTY.mdx"
 
 <PartialCommand />
 
@@ -18,3 +19,6 @@ import PartialDisableScreen from "./terminal/disableScreen.mdx"
 
 
 <PartialDisableScreen />
+
+
+<PartialDisableTTY />

--- a/docs/pages/configuration/_partials/v2beta1/dev/terminal/disableTTY.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/terminal/disableTTY.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `disableTTY` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#dev-terminal-disableTTY}
+
+DisableTTY will disable a tty shell for terminal command execution
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/dev/terminal_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/terminal_reference.mdx
@@ -4,6 +4,7 @@ import PartialWorkDir from "./terminal/workDir.mdx"
 import PartialEnabled from "./terminal/enabled.mdx"
 import PartialDisableReplace from "./terminal/disableReplace.mdx"
 import PartialDisableScreen from "./terminal/disableScreen.mdx"
+import PartialDisableTTY from "./terminal/disableTTY.mdx"
 
 <PartialCommand />
 
@@ -18,3 +19,6 @@ import PartialDisableScreen from "./terminal/disableScreen.mdx"
 
 
 <PartialDisableScreen />
+
+
+<PartialDisableTTY />

--- a/docs/schemas/config-openapi.json
+++ b/docs/schemas/config-openapi.json
@@ -1821,6 +1821,10 @@
               "disableScreen": {
                 "type": "boolean",
                 "description": "DisableScreen will disable screen which is used by DevSpace by default to preserve\nsessions if connections interrupt or the session is lost."
+              },
+              "disableTTY": {
+                "type": "boolean",
+                "description": "DisableTTY will disable a tty shell for terminal command execution"
               }
             },
             "type": "object",

--- a/e2e/tests/imports/testdata/conditional/devspace.yaml
+++ b/e2e/tests/imports/testdata/conditional/devspace.yaml
@@ -1,0 +1,15 @@
+version: v2beta1
+name: base
+
+imports:
+  - path: ./${IMPORT1_PATH}
+
+vars:
+  IMPORT1_PATH:
+    source: env
+    default: import1.yaml
+
+pipelines:
+  deploy:
+    run: |-
+      echo ${IMPORT1} > import1.txt

--- a/e2e/tests/imports/testdata/conditional/import1.yaml
+++ b/e2e/tests/imports/testdata/conditional/import1.yaml
@@ -1,0 +1,5 @@
+version: v2beta1
+name: import1
+
+vars:
+  IMPORT1: import1

--- a/e2e/tests/imports/testdata/conditional/import2.yaml
+++ b/e2e/tests/imports/testdata/conditional/import2.yaml
@@ -1,0 +1,5 @@
+version: v2beta1
+name: import1
+
+vars:
+  IMPORT1: import2

--- a/pkg/devspace/config/loader/imports.go
+++ b/pkg/devspace/config/loader/imports.go
@@ -46,7 +46,7 @@ func ResolveImports(ctx context.Context, resolver variable.Resolver, basePath st
 		return nil, errors.Errorf("Version is missing in devspace.yaml")
 	}
 
-	rawImportsInterface, err := resolver.FillVariablesInclude(ctx, rawImports, []string{"/imports/*/enabled"})
+	rawImportsInterface, err := resolver.FillVariablesInclude(ctx, rawImports, []string{"/imports/**"})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devspace/config/loader/variable/resolver.go
+++ b/pkg/devspace/config/loader/variable/resolver.go
@@ -260,8 +260,8 @@ func (r *resolver) insertVariableGraph(g *graph.Graph, node *latest.Variable) er
 func (r *resolver) FillVariablesInclude(ctx context.Context, haystack interface{}, includedPaths []string) (interface{}, error) {
 	paths := []*regexp.Regexp{}
 	for _, path := range includedPaths {
-		path = strings.ReplaceAll(path, "*", "[^/]+")
 		path = strings.ReplaceAll(path, "**", ".+")
+		path = strings.ReplaceAll(path, "*", "[^/]+")
 		path = "^" + path + "$"
 		expr, err := regexp.Compile(path)
 		if err != nil {
@@ -290,8 +290,8 @@ func (r *resolver) FillVariablesInclude(ctx context.Context, haystack interface{
 func (r *resolver) FillVariablesExclude(ctx context.Context, haystack interface{}, excludedPaths []string) (interface{}, error) {
 	paths := []*regexp.Regexp{}
 	for _, path := range excludedPaths {
-		path = strings.ReplaceAll(path, "*", "[^/]+")
 		path = strings.ReplaceAll(path, "**", ".+")
+		path = strings.ReplaceAll(path, "*", "[^/]+")
 		path = "^" + path + "$"
 		expr, err := regexp.Compile(path)
 		if err != nil {

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1234,6 +1234,9 @@ type Terminal struct {
 	// DisableScreen will disable screen which is used by DevSpace by default to preserve
 	// sessions if connections interrupt or the session is lost.
 	DisableScreen bool `yaml:"disableScreen,omitempty" json:"disableScreen,omitempty"`
+
+	// DisableTTY will disable a tty shell for terminal command execution
+	DisableTTY bool `yaml:"disableTTY,omitempty" json:"disableTTY,omitempty"`
 }
 
 // DependencyConfig defines the devspace dependency

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl.go
@@ -281,7 +281,7 @@ func (d *DeployConfig) buildManifests(ctx devspacecontext.Context, manifest stri
 		return NewKustomizeBuilder(kustomizePath, d.DeploymentConfig, ctx.Log()).Build(ctx.Context(), ctx.Environ(), ctx.WorkingDir(), manifest)
 	}
 
-	raw, err := ctx.KubeClient().KubeConfigLoader().LoadConfig().RawConfig()
+	raw, err := ctx.KubeClient().KubeConfigLoader().LoadRawConfig()
 	if err != nil {
 		return nil, fmt.Errorf("get raw config")
 	}

--- a/pkg/devspace/kubectl/client.go
+++ b/pkg/devspace/kubectl/client.go
@@ -108,6 +108,7 @@ func NewClientFromContext(context, namespace string, switchContext bool, kubeLoa
 		return nil, err
 	}
 	restConfig.UserAgent = "DevSpace Version " + upgrade.GetVersion()
+
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "new client")

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/wait_pod.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/wait_pod.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/jessevdk/go-flags"
+	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
+	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
+	"github.com/pkg/errors"
+	"time"
+)
+
+type WaitPodOptions struct {
+	ImageSelector string `long:"image-selector" description:"The image selector to use to select the container"`
+	LabelSelector string `long:"label-selector" description:"The label selector to use to select the container"`
+	Container     string `long:"container" description:"The container to use"`
+
+	Namespace   string `long:"namespace" short:"n" description:"The namespace to use"`
+	DisableWait bool   `long:"disable-wait" description:"If true, will not wait for the container to become ready"`
+	Timeout     int64  `long:"timeout" description:"The timeout to wait. Defaults to 5 minutes"`
+}
+
+func WaitPod(ctx devspacecontext.Context, args []string) error {
+	if ctx.KubeClient() == nil {
+		return errors.Errorf(ErrMsg)
+	}
+	options := &WaitPodOptions{
+		Namespace: ctx.KubeClient().Namespace(),
+	}
+	args, err := flags.ParseArgs(options, args)
+	if err != nil {
+		return errors.Wrap(err, "parse args")
+	}
+	if len(args) != 0 {
+		return fmt.Errorf("usage: wait_pod [--image-selector|--label-selector]")
+	}
+	if options.ImageSelector == "" && options.LabelSelector == "" {
+		return fmt.Errorf("usage: wait_pod [--image-selector|--label-selector]")
+	}
+
+	logger := ctx.Log().ErrorStreamOnly()
+	selectorOptions := targetselector.NewOptionsFromFlags(options.Container, options.LabelSelector, []string{options.ImageSelector}, options.Namespace, "")
+	if options.Timeout != 0 {
+		selectorOptions = selectorOptions.WithTimeout(options.Timeout)
+	}
+	selectorOptions.WithWaitingStrategy(targetselector.NewUntilNewestRunningWaitingStrategy(time.Millisecond * 100))
+	_, err = targetselector.NewTargetSelector(selectorOptions).SelectSingleContainer(ctx.Context(), ctx.KubeClient(), logger)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/handler.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/handler.go
@@ -76,6 +76,9 @@ var PipelineCommands = map[string]func(devCtx devspacecontext.Context, pipeline 
 	"select_pod": func(devCtx devspacecontext.Context, pipeline types.Pipeline, args []string) error {
 		return commands.SelectPod(devCtx, args)
 	},
+	"wait_pod": func(devCtx devspacecontext.Context, pipeline types.Pipeline, args []string) error {
+		return commands.WaitPod(devCtx, args)
+	},
 }
 
 func init() {

--- a/pkg/devspace/server/server.go
+++ b/pkg/devspace/server/server.go
@@ -121,7 +121,7 @@ type forward struct {
 }
 
 func newHandler(ctx devspacecontext.Context, path string, pipeline types.Pipeline) (*handler, error) { // Get kube config
-	kubeConfig, err := kubeconfig.NewLoader().LoadConfig().RawConfig()
+	kubeConfig, err := kubeconfig.NewLoader().LoadRawConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "load kube config")
 	}

--- a/pkg/util/scanner/scanner.go
+++ b/pkg/util/scanner/scanner.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 )
 
@@ -9,5 +10,28 @@ func NewScanner(r io.Reader) *bufio.Scanner {
 	scanner := bufio.NewScanner(r)
 	buf := make([]byte, 0, 64*1024)
 	scanner.Buffer(buf, 1024*1024)
+	scanner.Split(ScanLines)
 	return scanner
+}
+
+// ScanLines is a split function for a Scanner that returns each line of
+// text, stripped of any trailing end-of-line marker. The returned line may
+// be empty. The end-of-line marker is one optional carriage return followed
+// by one mandatory newline. In regular expression notation, it is `\r?\n`.
+// The last non-empty line of input will be returned even if it has no
+// newline.
+func ScanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		// We have a full newline-terminated line.
+		return i + 1, data[0:i], nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2270
resolves #2271


**Please provide a short message that should be published in the DevSpace release notes**
- Fixed an issue where DevSpace would incorrectly omit `\r` in pipeline commands
- New `--tty` flag for `devspace enter` to disable tty
- New `dev.terminal.disableTTY` option to disable tty 
- New `wait_pod` function for pipelines that waits for pods / containers to become ready 
- Variables can now be used in the whole imports section
