### PR TITLE
Set silence flag to false in devspace init command to show logs on the screen

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -791,7 +791,7 @@ func (cmd *InitCmd) render(f factory.Factory, config *latest.Config) (string, er
 	writer := &bytes.Buffer{}
 	renderCmd := &RunPipelineCmd{
 		GlobalFlags: &flags.GlobalFlags{
-			Silent:     true,
+			Silent:     false,
 			ConfigPath: renderPath,
 		},
 		Pipeline:     "deploy",
@@ -799,7 +799,6 @@ func (cmd *InitCmd) render(f factory.Factory, config *latest.Config) (string, er
 		SkipBuild:    true,
 		Render:       true,
 		RenderWriter: writer,
-		Log:          &log.DiscardLogger{},
 	}
 	err = renderCmd.RunDefault(f)
 	if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -787,11 +787,15 @@ func (cmd *InitCmd) render(f factory.Factory, config *latest.Config) (string, er
 		return "", errors.Wrap(err, "temp render.yaml")
 	}
 
+	silent := true
+	if cmd.Debug {
+		silent = false
+	}
 	// Use the render command to render it.
 	writer := &bytes.Buffer{}
 	renderCmd := &RunPipelineCmd{
 		GlobalFlags: &flags.GlobalFlags{
-			Silent:     false,
+			Silent:     silent,
 			ConfigPath: renderPath,
 		},
 		Pipeline:     "deploy",


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2217 


**Please provide a short message that should be published in the DevSpace release notes**
Silent params value being true used to discard the logs, setting it to false will now show the logs on the terminal when --debug is enabled. 


**What else do we need to know?** 
Setting the silent flag to true so that the error in init command will be output on the terminal when --debug is enabled