### PR TITLE
fix: use identity token when password is not set

### DIFF
--- a/pkg/devspace/docker/auth.go
+++ b/pkg/devspace/docker/auth.go
@@ -39,7 +39,6 @@ func (c *client) Login(ctx context.Context, registryURL, user, password string, 
 	}
 
 	authConfig, err := getDefaultAuthConfig(checkCredentialsStore, serverAddress, isDefaultRegistry)
-	authConfig.IdentityToken = ""
 	if err != nil || authConfig.Username == "" || authConfig.Password == "" || relogin {
 		authConfig.Username = strings.TrimSpace(user)
 		authConfig.Password = strings.TrimSpace(password)

--- a/pkg/devspace/pullsecrets/init.go
+++ b/pkg/devspace/pullsecrets/init.go
@@ -1,10 +1,11 @@
 package pullsecrets
 
 import (
+	"time"
+
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
 	"github.com/loft-sh/devspace/pkg/devspace/docker"
 	"github.com/loft-sh/devspace/pkg/util/stringutil"
-	"time"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/hook"
@@ -166,6 +167,10 @@ func (r *client) createPullSecret(ctx devspacecontext.Context, dockerClient dock
 		if authConfig != nil {
 			username = authConfig.Username
 			password = authConfig.Password
+
+			if password == "" && authConfig.IdentityToken != "" {
+				password = authConfig.IdentityToken
+			}
 		}
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #2278


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace skipped creating a pull secret when logged in with Azure container registry.