### PR TITLE
Add DEVSPACE_PROFILES variable and is_in command

### DIFF
--- a/pkg/devspace/config/loader/loader.go
+++ b/pkg/devspace/config/loader/loader.go
@@ -3,15 +3,16 @@ package loader
 import (
 	"context"
 	"fmt"
-	"github.com/loft-sh/devspace/pkg/devspace/context/values"
-	"github.com/loft-sh/devspace/pkg/util/encoding"
-	"github.com/loft-sh/devspace/pkg/util/yamlutil"
 	"io/ioutil"
-	"mvdan.cc/sh/v3/expand"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/loft-sh/devspace/pkg/devspace/context/values"
+	"github.com/loft-sh/devspace/pkg/util/encoding"
+	"github.com/loft-sh/devspace/pkg/util/yamlutil"
+	"mvdan.cc/sh/v3/expand"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/localcache"
 	"github.com/loft-sh/devspace/pkg/devspace/config/remotecache"
@@ -301,7 +302,7 @@ func (l *configLoader) parseConfig(
 	resolver, err := variable.NewResolver(localCache, &variable.PredefinedVariableOptions{
 		ConfigPath: l.absConfigPath,
 		KubeClient: client,
-		Profile:    GetLastProfile(options.Profiles),
+		Profile:    options.Profiles,
 	}, options.Vars, log)
 	if err != nil {
 		return nil, nil, nil, err
@@ -565,13 +566,6 @@ func (l *configLoader) applyProfiles(ctx context.Context, data map[string]interf
 	}
 
 	return data, nil
-}
-
-func GetLastProfile(profiles []string) string {
-	if len(profiles) == 0 {
-		return ""
-	}
-	return profiles[len(profiles)-1]
 }
 
 // configExistsInPath checks whether a devspace configuration exists at a certain path

--- a/pkg/devspace/config/loader/variable/predefined_variable.go
+++ b/pkg/devspace/config/loader/variable/predefined_variable.go
@@ -79,7 +79,7 @@ var predefinedVars = map[string]PredefinedVariableFunction{
 		return GetLastProfile(options.Profile), nil
 	},
 	"DEVSPACE_PROFILES": func(ctx context.Context, options *PredefinedVariableOptions, log log.Logger) (interface{}, error) {
-		return options.Profile, nil
+		return strings.Join(options.Profile, " "), nil
 	},
 	"DEVSPACE_USER_HOME": func(ctx context.Context, options *PredefinedVariableOptions, log log.Logger) (interface{}, error) {
 		homeDir, err := homedir.Dir()

--- a/pkg/devspace/config/loader/variable/predefined_variable.go
+++ b/pkg/devspace/config/loader/variable/predefined_variable.go
@@ -6,17 +6,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/loft-sh/devspace/pkg/devspace/context/values"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/util/downloader"
 	"github.com/loft-sh/devspace/pkg/util/downloader/commands"
 	"github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/sirupsen/logrus"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/plugin"
@@ -30,7 +31,7 @@ import (
 type PredefinedVariableOptions struct {
 	ConfigPath string
 	KubeClient kubectl.Client
-	Profile    string
+	Profile    []string
 }
 
 // PredefinedVariableFunction is the definition of a predefined variable
@@ -75,6 +76,9 @@ var predefinedVars = map[string]PredefinedVariableFunction{
 		return randutil.GenerateRandomString(6), nil
 	},
 	"DEVSPACE_PROFILE": func(ctx context.Context, options *PredefinedVariableOptions, log log.Logger) (interface{}, error) {
+		return GetLastProfile(options.Profile), nil
+	},
+	"DEVSPACE_PROFILES": func(ctx context.Context, options *PredefinedVariableOptions, log log.Logger) (interface{}, error) {
 		return options.Profile, nil
 	},
 	"DEVSPACE_USER_HOME": func(ctx context.Context, options *PredefinedVariableOptions, log log.Logger) (interface{}, error) {
@@ -193,4 +197,11 @@ func (p *predefinedVariable) Load(ctx context.Context, definition *latest.Variab
 	}
 
 	return getVar(ctx, p.options, p.log)
+}
+
+func GetLastProfile(profiles []string) string {
+	if len(profiles) == 0 {
+		return ""
+	}
+	return profiles[len(profiles)-1]
 }

--- a/pkg/devspace/config/loader/variable/resolver.go
+++ b/pkg/devspace/config/loader/variable/resolver.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var AlwaysResolvePredefinedVars = []string{"DEVSPACE_NAME", "DEVSPACE_EXECUTABLE", "DEVSPACE_KUBECTL_EXECUTABLE", "DEVSPACE_TMPDIR", "DEVSPACE_VERSION", "DEVSPACE_RANDOM", "DEVSPACE_PROFILE", "DEVSPACE_USER_HOME", "DEVSPACE_TIMESTAMP", "devspace.context", "DEVSPACE_CONTEXT", "devspace.namespace", "DEVSPACE_NAMESPACE"}
+var AlwaysResolvePredefinedVars = []string{"DEVSPACE_NAME", "DEVSPACE_EXECUTABLE", "DEVSPACE_KUBECTL_EXECUTABLE", "DEVSPACE_TMPDIR", "DEVSPACE_VERSION", "DEVSPACE_RANDOM", "DEVSPACE_PROFILE", "DEVSPACE_PROFILES", "DEVSPACE_USER_HOME", "DEVSPACE_TIMESTAMP", "devspace.context", "DEVSPACE_CONTEXT", "devspace.namespace", "DEVSPACE_NAMESPACE"}
 
 // NewResolver creates a new resolver that caches resolved variables in memory and in the provided cache
 func NewResolver(localCache localcache.Cache, predefinedVariableOptions *PredefinedVariableOptions, flags []string, log log.Logger) (Resolver, error) {

--- a/pkg/devspace/pipeline/engine/basichandler/commands/is_in.go
+++ b/pkg/devspace/pipeline/engine/basichandler/commands/is_in.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"mvdan.cc/sh/v3/interp"
+)
+
+func IsIn(args []string) error {
+	if len(args) < 2 {
+		return interp.NewExitStatus(1)
+	}
+	needed := args[0]
+	for _, value := range args[1:] {
+		if value == needed {
+			return interp.NewExitStatus(0)
+		}
+	}
+	return interp.NewExitStatus(1)
+}

--- a/pkg/devspace/pipeline/engine/basichandler/commands/is_in.go
+++ b/pkg/devspace/pipeline/engine/basichandler/commands/is_in.go
@@ -1,16 +1,18 @@
 package commands
 
 import (
+	"strings"
+
 	"mvdan.cc/sh/v3/interp"
 )
 
 func IsIn(args []string) error {
-	if len(args) < 2 {
+	if len(args) != 2 {
 		return interp.NewExitStatus(1)
 	}
-	needed := args[0]
-	for _, value := range args[1:] {
-		if value == needed {
+	values := strings.Split(args[1], " ")
+	for _, value := range values {
+		if value == args[0] {
 			return interp.NewExitStatus(0)
 		}
 	}

--- a/pkg/devspace/pipeline/engine/basichandler/handler.go
+++ b/pkg/devspace/pipeline/engine/basichandler/handler.go
@@ -3,6 +3,9 @@ package basichandler
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
+
 	enginecommands "github.com/loft-sh/devspace/pkg/devspace/pipeline/engine/basichandler/commands"
 	"github.com/loft-sh/devspace/pkg/devspace/pipeline/engine/types"
 	"github.com/loft-sh/devspace/pkg/util/downloader"
@@ -10,8 +13,6 @@ import (
 	"github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/pkg/errors"
 	"mvdan.cc/sh/v3/interp"
-	"os"
-	"time"
 )
 
 // BasicCommands are extra commands DevSpace provides within the shell or are common
@@ -31,6 +32,9 @@ var BasicCommands = map[string]func(ctx context.Context, args []string) error{
 	},
 	"is_true": func(ctx context.Context, args []string) error {
 		return enginecommands.IsTrue(args)
+	},
+	"is_in": func(ctx context.Context, args []string) error {
+		return enginecommands.IsIn(args)
 	},
 	"sleep": func(ctx context.Context, args []string) error {
 		return HandleError(ctx, "sleep", enginecommands.Sleep(ctx, args))


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

Add builtin `DEVSPACE_PROFILES` variable containing all enabled profiles


**Please provide a short message that should be published in the DevSpace release notes**
Add `DEVSPACE_PROFILES` variable


**What else do we need to know?** 
For now it is still a draft because the variable is an array and is "converted" into a list of string with extra `[` and `]`. Need to figure out how to resolve that 
