### PR TITLE
docs: hide deprecated printLogs & remoteExec configs in docs

### DIFF
--- a/devspace-schema.json
+++ b/devspace-schema.json
@@ -1698,10 +1698,6 @@
         "file": {
           "type": "boolean",
           "description": "File signals DevSpace that this is a single file that should get synced instead of a whole directory"
-        },
-        "printLogs": {
-          "type": "boolean",
-          "description": "PrintLogs defines if sync logs should be displayed on the terminal"
         }
       },
       "type": "object",
@@ -1790,7 +1786,7 @@
         },
         "execRemote": {
           "$ref": "#/$defs/SyncExecCommand",
-          "description": "Defines what commands should be executed on the container side if a change is uploaded and applied in the target\ncontainer"
+          "description": "Defines what commands should be executed on the container side if a change is uploaded and applied in the target\ncontainer. Deprecated, use `Exec`."
         }
       },
       "type": "object",

--- a/docs/pages/configuration/_partials/v2beta1/deployments/updateImageTags.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/updateImageTags.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `updateImageTags` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deployments-updateImageTags}
+### `updateImageTags` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deployments-updateImageTags}
 
 UpdateImageTags lets you define if DevSpace should update the tags of the images defined in the
 images section with their most recent built tag.

--- a/docs/pages/configuration/_partials/v2beta1/dev/containers/sync/onUpload/execRemote.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/containers/sync/onUpload/execRemote.mdx
@@ -8,7 +8,7 @@ import PartialExecRemotereference from "./execRemote_reference.mdx"
 ###### `execRemote` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dev-containers-sync-onUpload-execRemote}
 
 Defines what commands should be executed on the container side if a change is uploaded and applied in the target
-container
+container. Deprecated, use `Exec`.
 
 </summary>
 

--- a/docs/pages/configuration/_partials/v2beta1/dev/containers/sync/onUpload_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/containers/sync/onUpload_reference.mdx
@@ -1,7 +1,6 @@
 
 import PartialRestartContainer from "./onUpload/restartContainer.mdx"
 import PartialExecreference from "./onUpload/exec_reference.mdx"
-import PartialExecRemotereference from "./onUpload/execRemote_reference.mdx"
 
 <PartialRestartContainer />
 
@@ -17,23 +16,6 @@ Exec will execute the given commands in order after a sync operation
 </summary>
 
 <PartialExecreference />
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-###### `execRemote` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dev-containers-sync-onUpload-execRemote}
-
-Defines what commands should be executed on the container side if a change is uploaded and applied in the target
-container
-
-</summary>
-
-<PartialExecRemotereference />
 
 
 </details>

--- a/docs/pages/configuration/_partials/v2beta1/dev/containers/sync_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/containers/sync_reference.mdx
@@ -8,7 +8,6 @@ import PartialBandwidthLimitsreference from "./sync/bandwidthLimits_reference.md
 import PartialPolling from "./sync/polling.mdx"
 import PartialNoWatch from "./sync/noWatch.mdx"
 import PartialFile from "./sync/file.mdx"
-import PartialPrintLogs from "./sync/printLogs.mdx"
 
 <PartialPath />
 
@@ -49,6 +48,3 @@ sync configuration
 
 
 <PartialFile />
-
-
-<PartialPrintLogs />

--- a/docs/pages/configuration/_partials/v2beta1/dev/sync/onUpload/execRemote.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/sync/onUpload/execRemote.mdx
@@ -8,7 +8,7 @@ import PartialExecRemotereference from "./execRemote_reference.mdx"
 ##### `execRemote` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dev-sync-onUpload-execRemote}
 
 Defines what commands should be executed on the container side if a change is uploaded and applied in the target
-container
+container. Deprecated, use `Exec`.
 
 </summary>
 

--- a/docs/pages/configuration/_partials/v2beta1/dev/sync/onUpload_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/sync/onUpload_reference.mdx
@@ -1,7 +1,6 @@
 
 import PartialRestartContainer from "./onUpload/restartContainer.mdx"
 import PartialExecreference from "./onUpload/exec_reference.mdx"
-import PartialExecRemotereference from "./onUpload/execRemote_reference.mdx"
 
 <PartialRestartContainer />
 
@@ -17,23 +16,6 @@ Exec will execute the given commands in order after a sync operation
 </summary>
 
 <PartialExecreference />
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `execRemote` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dev-sync-onUpload-execRemote}
-
-Defines what commands should be executed on the container side if a change is uploaded and applied in the target
-container
-
-</summary>
-
-<PartialExecRemotereference />
 
 
 </details>

--- a/docs/pages/configuration/_partials/v2beta1/dev/sync_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/sync_reference.mdx
@@ -8,7 +8,6 @@ import PartialBandwidthLimitsreference from "./sync/bandwidthLimits_reference.md
 import PartialPolling from "./sync/polling.mdx"
 import PartialNoWatch from "./sync/noWatch.mdx"
 import PartialFile from "./sync/file.mdx"
-import PartialPrintLogs from "./sync/printLogs.mdx"
 
 <PartialPath />
 
@@ -49,6 +48,3 @@ sync configuration
 
 
 <PartialFile />
-
-
-<PartialPrintLogs />

--- a/docs/schemas/config-openapi.json
+++ b/docs/schemas/config-openapi.json
@@ -1706,10 +1706,6 @@
               "file": {
                 "type": "boolean",
                 "description": "File signals DevSpace that this is a single file that should get synced instead of a whole directory"
-              },
-              "printLogs": {
-                "type": "boolean",
-                "description": "PrintLogs defines if sync logs should be displayed on the terminal"
               }
             },
             "type": "object",
@@ -1798,7 +1794,7 @@
               },
               "execRemote": {
                 "$ref": "#/definitions/Config/$defs/SyncExecCommand",
-                "description": "Defines what commands should be executed on the container side if a change is uploaded and applied in the target\ncontainer"
+                "description": "Defines what commands should be executed on the container side if a change is uploaded and applied in the target\ncontainer. Deprecated, use `Exec`."
               }
             },
             "type": "object",

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1104,7 +1104,7 @@ type SyncConfig struct {
 	File bool `yaml:"file,omitempty" json:"file,omitempty"`
 
 	// PrintLogs defines if sync logs should be displayed on the terminal
-	PrintLogs bool `yaml:"printLogs,omitempty" json:"printLogs,omitempty"`
+	PrintLogs bool `yaml:"printLogs,omitempty" json:"printLogs,omitempty" jsonschema:"-"`
 }
 
 type ContainerArchitecture string
@@ -1125,8 +1125,8 @@ type SyncOnUpload struct {
 	Exec []SyncExec `yaml:"exec,omitempty" json:"exec,omitempty"`
 
 	// Defines what commands should be executed on the container side if a change is uploaded and applied in the target
-	// container
-	ExecRemote *SyncExecCommand `yaml:"execRemote,omitempty" json:"execRemote,omitempty"`
+	// container. Deprecated, use `Exec`.
+	ExecRemote *SyncExecCommand `yaml:"execRemote,omitempty" json:"execRemote,omitempty" jsonschema:"-"`
 }
 
 type SyncExec struct {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves N/A


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace docs showed some deprecated configs on the config reference docs


**What else do we need to know?**
N/A