### PR TITLE
feat: fallback to ssh if https doesn't work and vice versa

### DIFF
--- a/pkg/devspace/dependency/util/util_test.go
+++ b/pkg/devspace/dependency/util/util_test.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestSwitchURLType(t *testing.T) {
+	httpURL := "https://github.com/loft-sh/devspace.git"
+	sshURL := "git@github.com:loft-sh/devspace.git"
+
+	assert.Equal(t, sshURL, switchURLType(httpURL))
+	assert.Equal(t, httpURL, switchURLType(sshURL))
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2323


**Please provide a short message that should be published in the DevSpace release notes**
Added a new feature where devspace will use ssh if https fails and vice versa while pulling dependency.

