### PR TITLE
fix: use registry token for pull secrets

### DIFF
--- a/pkg/devspace/pullsecrets/init.go
+++ b/pkg/devspace/pullsecrets/init.go
@@ -1,6 +1,7 @@
 package pullsecrets
 
 import (
+	"strings"
 	"time"
 
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
@@ -170,6 +171,12 @@ func (r *client) createPullSecret(ctx devspacecontext.Context, dockerClient dock
 
 			if password == "" && authConfig.IdentityToken != "" {
 				password = authConfig.IdentityToken
+			}
+
+			// Handle Azure Container Registry (ACR) when credentials helper does not provide a username
+			// https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#az-acr-login-with---expose-token
+			if username == "" && strings.HasSuffix(authConfig.ServerAddress, "azurecr.io") {
+				username = "00000000-0000-0000-0000-000000000000"
 			}
 		}
 	}


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #2324

The `wincred` credential store returns an empty `username` when resolving credentials. Because of this, we skip creating the pull secret since we don't have complete credentials.

The solution is to provide a username of `00000000-0000-0000-0000-000000000000` when using ACR, [according to their docs](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#az-acr-login-with---expose-token). This issue is specific to the `wincred` credential store.

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would not create a pull secret when using `wincred` credentials store
