### PR TITLE
fix: dependencies resolved unexpectedly when disabled

### DIFF
--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -3,16 +3,17 @@ package framework
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/go-resty/resty/v2"
 	"github.com/loft-sh/devspace/e2e/kube"
 	"github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"io/ioutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"os"
-	"strings"
-	"time"
 )
 
 // ExpectEqual expects the specified two are the same, otherwise an exception raises
@@ -158,6 +159,12 @@ func ExpectLocalFileContentsImmediately(filePath string, contents string) {
 	out, err := ioutil.ReadFile(filePath)
 	ExpectNoError(err)
 	gomega.ExpectWithOffset(1, string(out)).To(gomega.Equal(contents))
+}
+
+func ExpectLocalFileContainSubstringImmediately(filePath string, contents string) {
+	out, err := ioutil.ReadFile(filePath)
+	ExpectNoError(err)
+	gomega.ExpectWithOffset(1, string(out)).To(gomega.ContainSubstring(contents))
 }
 
 func ExpectLocalFileContents(filePath string, contents string) {

--- a/e2e/tests/dependencies/testdata/disabled/devspace-all.yaml
+++ b/e2e/tests/dependencies/testdata/disabled/devspace-all.yaml
@@ -1,0 +1,33 @@
+version: v2beta1
+vars:
+  DEP1_DISABLED:
+    default: false
+pipelines:
+  build:
+    run: run_dependencies --all --pipeline build
+  deploy:
+    run: |-
+      run_dependencies --all
+      create_deployments nginx --sequential
+  dev:
+    run: |-
+      run_dependencies --all
+      create_deployments nginx --sequential
+
+      start_dev --all
+  purge:
+    run: |-
+      stop_dev --all
+      purge_deployments nginx --sequential
+
+      run_dependencies --all --pipeline purge
+deployments:
+  nginx:
+    helm:
+      values:
+        containers:
+          - image: nginx
+dependencies:
+  dep1:
+    disabled: ${DEP1_DISABLED}
+    git: https://github.com/doesntexist/youcantcloneme

--- a/e2e/tests/dependencies/testdata/disabled/devspace-name.yaml
+++ b/e2e/tests/dependencies/testdata/disabled/devspace-name.yaml
@@ -1,0 +1,33 @@
+version: v2beta1
+vars:
+  DEP1_DISABLED:
+    default: false
+pipelines:
+  build:
+    run: run_dependencies dep1 --pipeline build
+  deploy:
+    run: |-
+      run_dependencies dep1
+      create_deployments nginx --sequential
+  dev:
+    run: |-
+      run_dependencies dep1
+      create_deployments nginx --sequential
+
+      start_dev --all
+  purge:
+    run: |-
+      stop_dev --all
+      purge_deployments nginx --sequential
+
+      run_dependencies dep1 --pipeline purge
+deployments:
+  nginx:
+    helm:
+      values:
+        containers:
+          - image: nginx
+dependencies:
+  dep1:
+    disabled: ${DEP1_DISABLED}
+    git: https://github.com/doesntexist/youcantcloneme

--- a/e2e/tests/dependencies/testdata/disabled/devspace.yaml
+++ b/e2e/tests/dependencies/testdata/disabled/devspace.yaml
@@ -1,0 +1,16 @@
+version: v1beta11
+vars:
+- name: DEP1_DISABLED
+  default: false
+deployments:
+- name: nginx1
+  helm:
+    componentChart: true
+    values:
+      containers:
+      - image: nginx
+dependencies:
+  - name: dep1
+    disabled: ${DEP1_DISABLED}
+    source:
+      git: https://github.com/doesntexist/youcantcloneme

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1248,6 +1248,9 @@ type DependencyConfig struct {
 	// Name is used internally
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
+	// Disabled excludes this dependency from variable resolution and pipeline runs
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+
 	// Source holds the dependency project
 	Source *SourceConfig `yaml:",inline" json:",inline"`
 

--- a/pkg/devspace/config/versions/v1beta11/upgrade.go
+++ b/pkg/devspace/config/versions/v1beta11/upgrade.go
@@ -145,6 +145,7 @@ func (c *Config) Upgrade(log log.Logger) (config.Config, error) {
 			OverwriteVars:            dep.OverwriteVars,
 			IgnoreDependencies:       dep.IgnoreDependencies,
 			Namespace:                dep.Namespace,
+			Disabled:                 dep.Disabled,
 		}
 		if dep.Profile != "" {
 			nextConfig.Dependencies[name].Profiles = append(nextConfig.Dependencies[name].Profiles, dep.Profile)

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -119,6 +119,12 @@ func (r *resolver) resolveRecursive(ctx devspacecontext.Context, basePath, paren
 		if contains(options.SkipDependencies, dependencyConfig.Name) {
 			continue
 		}
+
+		if dependencyConfig.Disabled {
+			ctx.Log().Debugf("Skip dependency %s, because it is disabled", dependencyConfig.Name)
+			continue
+		}
+
 		dependencyConfigPath, err := util.DownloadDependency(ctx.Context(), basePath, dependencyConfig.Source, ctx.Log())
 		if err != nil {
 			return err


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #2352

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would resolve disabled dependencies

**What else do we need to know?** 
- `run_dependencies --all`: will run as expected
- `run_dependencies dep1`: will error if `dep1` is disabled since it was never resolved; Is this the desired behavior?
