### PR TITLE
Fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us reproduce and fix a bug
-
+labels:
+- kind/bug
 ---
 
 <!-- Please use this template for reporting bugs and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!-->
@@ -29,8 +30,3 @@ version: ...
 - Kubernetes Version: [use `kubectl version`]
 
 **Anything else we need to know?**  
-
-
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/kind bug

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
+labels:
+- kind/feature
 ---
 
 **Is your feature request related to a problem?**  
@@ -14,7 +15,3 @@ about: Suggest an idea for this project
 
 
 **Additional context**  
-
-
-<!-- DO NOT EDIT BELOW THIS LINE -->
-/kind feature


### PR DESCRIPTION
**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Should fix automatically assigned labels for the new issues.
If you look at the recently reported issues they are missing the "kind" label (except where added manually).


**Please provide a short message that should be published in the DevSpace release notes**
N/A


**What else do we need to know?** 
I am not sure why it stopped working, I just copied the config from our vcluster repo.