### PR TITLE
fix: skip /auth call for ACR registries

### DIFF
--- a/pkg/devspace/pullsecrets/init.go
+++ b/pkg/devspace/pullsecrets/init.go
@@ -1,7 +1,6 @@
 package pullsecrets
 
 import (
-	"strings"
 	"time"
 
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
@@ -18,6 +17,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const AzureContainerRegistryUsername = "00000000-0000-0000-0000-000000000000"
 
 func (r *client) EnsurePullSecret(ctx devspacecontext.Context, dockerClient docker.Client, namespace, registryURL string) error {
 	pullSecret := &latest.PullSecretConfig{Registry: registryURL}
@@ -175,8 +176,8 @@ func (r *client) createPullSecret(ctx devspacecontext.Context, dockerClient dock
 
 			// Handle Azure Container Registry (ACR) when credentials helper does not provide a username
 			// https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#az-acr-login-with---expose-token
-			if username == "" && strings.HasSuffix(authConfig.ServerAddress, "azurecr.io") {
-				username = "00000000-0000-0000-0000-000000000000"
+			if username == "" && IsAzureContainerRegistry(authConfig.ServerAddress) {
+				username = AzureContainerRegistryUsername
 			}
 		}
 	}

--- a/pkg/devspace/pullsecrets/util.go
+++ b/pkg/devspace/pullsecrets/util.go
@@ -1,6 +1,8 @@
 package pullsecrets
 
 import (
+	"strings"
+
 	"github.com/docker/distribution/reference"
 	dockerregistry "github.com/docker/docker/registry"
 )
@@ -22,4 +24,8 @@ func GetRegistryFromImageName(imageName string) (string, error) {
 	}
 
 	return repoInfo.Index.Name, nil
+}
+
+func IsAzureContainerRegistry(serverAddress string) bool {
+	return strings.HasSuffix(serverAddress, "azurecr.io")
 }


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2365


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace always attempts a registry authentication call. Azure Container registries use a different authentication method, and no longer responds correctly to `/auth` requests. They [encourage users to use `az acr login` to refresh their credentials instead](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#individual-login-with-azure-ad).


**What else do we need to know?** 
DevSpace will log a message reminding users that they can refresh their credentials with `az acr login`