### PR TITLE
feat: support "~" (home) at the start of sync path

### DIFF
--- a/pkg/devspace/context/context.go
+++ b/pkg/devspace/context/context.go
@@ -2,6 +2,12 @@ package context
 
 import (
 	context2 "context"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
 	"github.com/loft-sh/devspace/pkg/devspace/config"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
@@ -11,11 +17,6 @@ import (
 	"github.com/loft-sh/devspace/pkg/util/tomb"
 	"github.com/pkg/errors"
 	"mvdan.cc/sh/v3/expand"
-	"os"
-	"path"
-	"path/filepath"
-	"runtime"
-	"strings"
 )
 
 func NewContext(ctx context2.Context, variables map[string]interface{}, log log.Logger) Context {
@@ -196,6 +197,15 @@ func (c *context) ResolvePath(relPath string) string {
 	relPath = filepath.ToSlash(relPath)
 	if filepath.IsAbs(relPath) {
 		return path.Clean(relPath)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err == nil {
+		if relPath == "~" {
+			return homeDir
+		} else if strings.HasPrefix(relPath, "~/") {
+			return path.Clean(filepath.Join(homeDir, relPath[2:]))
+		}
 	}
 
 	outPath := path.Join(filepath.ToSlash(c.workingDir), relPath)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Allows users to use the tilde `~` to refer to their home directory in sync path, e.g.:
```
    sync:
    - path: ~/.m2/settings.xml:./bindings/maven/settings.xml
      file: true
```


**Please provide a short message that should be published in the DevSpace release notes**
Added support for the tilde `~` to refer to the home directory in the sync path.


**What else do we need to know?** 
I am surprised that this was not implemented before. Maybe there is a good reason for not supporting this?