### PR TITLE
Skip local registry use for vclusters on local kubernetes clusters

### DIFF
--- a/pkg/devspace/build/builder/docker/docker.go
+++ b/pkg/devspace/build/builder/docker/docker.go
@@ -212,7 +212,7 @@ func (b *Builder) BuildImage(ctx devspacecontext.Context, contextPath, dockerfil
 		// Push image to local registry
 		for _, tag := range buildOptions.Tags {
 			ctx.Log().Info("The push refers to repository [" + tag + "]")
-			err := registry.CopyImageToRemote(ctx.Context(), tag, writer)
+			err := registry.CopyImageToRemote(ctx.Context(), b.client, tag, writer)
 			if err != nil {
 				return errors.Errorf("error during local registry image push: %v", err)
 			}

--- a/pkg/devspace/build/registry/util_test.go
+++ b/pkg/devspace/build/registry/util_test.go
@@ -1,0 +1,262 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	kubectltesting "github.com/loft-sh/devspace/pkg/devspace/kubectl/testing"
+	"github.com/loft-sh/devspace/pkg/util/ptr"
+	"gotest.tools/assert"
+)
+
+type useLocalRegistryTestCase struct {
+	name     string
+	client   kubectl.Client
+	config   *latest.Config
+	skipPush bool
+	expected bool
+}
+
+func TestUseLocalRegistry(t *testing.T) {
+	testCases := []useLocalRegistryTestCase{
+		{
+			name: "KinD Cluster",
+			client: &kubectltesting.Client{
+				Context: "kind-kind",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "KinD Cluster Local Registry Enabled",
+			client: &kubectltesting.Client{
+				Context: "kind-kind",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: ptr.Bool(true),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "KinD Cluster Local Registry Enabled skip push",
+			client: &kubectltesting.Client{
+				Context: "kind-kind",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: ptr.Bool(true),
+				},
+			},
+			skipPush: true,
+			expected: false,
+		},
+		{
+			name: "KinD Cluster Local Registry Fallback",
+			client: &kubectltesting.Client{
+				Context: "kind-kind",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: nil,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "VCluster with KinD Cluster",
+			client: &kubectltesting.Client{
+				Context: "vcluster_devspace-kind_vcluster-devspace-kind_kind-kind",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "Docker Desktop Cluster",
+			client: &kubectltesting.Client{
+				Context: "docker-desktop",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "Docker Desktop Cluster Local Registry Enabled",
+			client: &kubectltesting.Client{
+				Context: "docker-desktop",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: ptr.Bool(true),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Docker Desktop Cluster Local Registry Enabled skip push",
+			client: &kubectltesting.Client{
+				Context: "docker-desktop",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: ptr.Bool(true),
+				},
+			},
+			skipPush: true,
+			expected: false,
+		},
+		{
+			name: "Docker Desktop Cluster Local Registry Fallback",
+			client: &kubectltesting.Client{
+				Context: "docker-desktop",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: nil,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "VCluster with Docker Desktop Cluster",
+			client: &kubectltesting.Client{
+				Context: "vcluster_devspacehelper_deploy-example_docker-desktop",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "Minikube Cluster",
+			client: &kubectltesting.Client{
+				Context: "minikube",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "Minikube Cluster Local Registry Enabled",
+			client: &kubectltesting.Client{
+				Context: "minikube",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: ptr.Bool(true),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Minikube Cluster Local Registry Enabled skip push",
+			client: &kubectltesting.Client{
+				Context: "minikube",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: ptr.Bool(true),
+				},
+			},
+			skipPush: true,
+			expected: false,
+		},
+		{
+			name: "Minikube Cluster Local Registry Fallback",
+			client: &kubectltesting.Client{
+				Context: "minikube",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: nil,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "VCluster with Minikube Cluster",
+			client: &kubectltesting.Client{
+				Context: "vcluster_devspace-minikube_vcluster-devspace-minikube_minikube",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "Remote Cluster",
+			client: &kubectltesting.Client{
+				Context: "arn:aws:eks:us-west-2:1234567890:cluster/remote-eks",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: true,
+		},
+		{
+			name: "Remote Cluster skip push",
+			client: &kubectltesting.Client{
+				Context: "arn:aws:eks:us-west-2:1234567890:cluster/remote-eks",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			skipPush: true,
+			expected: false,
+		},
+		{
+			name: "Remote Cluster Local Registry Disabled",
+			client: &kubectltesting.Client{
+				Context: "arn:aws:eks:us-west-2:1234567890:cluster/remote-eks",
+			},
+			config: &latest.Config{
+				LocalRegistry: &latest.LocalRegistryConfig{
+					Enabled: ptr.Bool(false),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "VCluster with Remote Cluster",
+			client: &kubectltesting.Client{
+				Context: "vcluster_vcluster-eks_vcluster-vcluster-eks_arn:aws:eks:us-west-2:1234567890:cluster/remote-eks",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: true,
+		},
+		{
+			name: "VCluster with Remote Cluster skip push",
+			client: &kubectltesting.Client{
+				Context: "vcluster_vcluster-eks_vcluster-vcluster-eks_arn:aws:eks:us-west-2:1234567890:cluster/remote-eks",
+			},
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			skipPush: true,
+			expected: false,
+		},
+		{
+			name:   "Nil KubeClient",
+			client: nil,
+			config: &latest.Config{
+				LocalRegistry: nil,
+			},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actual := UseLocalRegistry(testCase.client, testCase.config, testCase.skipPush)
+		assert.Equal(t, actual, testCase.expected, "Unexpected result in test case %s", testCase.name)
+	}
+}

--- a/pkg/devspace/docker/client.go
+++ b/pkg/devspace/docker/client.go
@@ -2,15 +2,17 @@ package docker
 
 import (
 	"context"
-	"github.com/loft-sh/loft-util/pkg/command"
 	"io"
-	"mvdan.cc/sh/v3/expand"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/loft-sh/loft-util/pkg/command"
+	"mvdan.cc/sh/v3/expand"
+
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/util/log"
 
 	dockertypes "github.com/docker/docker/api/types"
@@ -107,7 +109,7 @@ func newDockerClientFromEnvironment() (Client, error) {
 }
 
 func newDockerClientFromMinikube(ctx context.Context, currentKubeContext string) (Client, error) {
-	if currentKubeContext != "minikube" {
+	if !kubectl.IsMinikubeKubernetes(currentKubeContext) {
 		return nil, errNotMinikube
 	}
 

--- a/pkg/devspace/kubectl/util.go
+++ b/pkg/devspace/kubectl/util.go
@@ -3,6 +3,10 @@ package kubectl
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/portforward"
 	"github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/pkg/errors"
@@ -11,14 +15,13 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/transport/spdy"
-	"net"
-	"net/http"
-	"strings"
 )
 
-const minikubeContext = "minikube"
-const dockerDesktopContext = "docker-desktop"
-const dockerForDesktopContext = "docker-for-desktop"
+const (
+	minikubeContext         = "minikube"
+	dockerDesktopContext    = "docker-desktop"
+	dockerForDesktopContext = "docker-for-desktop"
+)
 
 // WaitStatus are the status to wait
 var WaitStatus = []string{
@@ -206,7 +209,23 @@ func IsLocalKubernetes(context string) bool {
 		context == dockerDesktopContext ||
 		context == dockerForDesktopContext {
 		return true
-	} else if strings.HasPrefix(context, "vcluster_") && (strings.HasSuffix(context, minikubeContext) || strings.HasSuffix(context, dockerDesktopContext) || strings.HasSuffix(context, dockerForDesktopContext)) {
+	} else if strings.HasPrefix(context, "vcluster_") &&
+		(strings.HasSuffix(context, minikubeContext) ||
+			strings.HasSuffix(context, dockerDesktopContext) ||
+			strings.HasSuffix(context, dockerForDesktopContext) ||
+			strings.Contains(context, "kind-")) {
+		return true
+	}
+
+	return false
+}
+
+func IsMinikubeKubernetes(context string) bool {
+	if context == minikubeContext {
+		return true
+	}
+
+	if strings.HasPrefix(context, "vcluster_") && strings.HasSuffix(context, minikubeContext) {
 		return true
 	}
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
- Resolves an issue where the local registry was used for vclusters on Minikube, Docker Desktop, and KinD clusters
- Refactored a few locations that were checking for Minikube that would have failed for vcluster & minikube
- Allow local registry to be used with Minikube when explicitly enabled

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace local registry was incorrectly used for virtual clusters on local Kubernetes clusters

**What else do we need to know?** 
Previously the local registry could never be used with minikube. These changes allow the user to opt in to the local registry with Minikube, and makes it consistent with the other local kubernetes options (KinD & Docker Desktop). There isn't a practical reason to do this, but using `localRegistry.enabled=true` in the config, and not having the local registry used was unexpected to some during testing.

There is also a [KinD issue ](https://github.com/kubernetes-sigs/kind/issues/2960)where `--force-build` creates a new tag, but `kind load docker-image` fails to re-tag the image in the KinD cluster, leading to an `ImagePullBackoff`. I've verified this issue exists in DevSpace version before the local registry feature was added. Using the local registry works as a workaround for this issue.