### PR TITLE
fix: use 'wss' protocol when ui is loaded via 'https'

### DIFF
--- a/ui/src/components/views/Commands/Commands/CommandsList/CommandsList.tsx
+++ b/ui/src/components/views/Commands/Commands/CommandsList/CommandsList.tsx
@@ -7,7 +7,7 @@ import PlayIcon from 'images/play-icon.svg';
 import PauseIcon from 'images/pause-blue-icon.svg';
 import IconButton from 'components/basic/IconButton/IconButton';
 import CodeSnippet from 'components/basic/CodeSnippet/CodeSnippet';
-import { ApiHostname } from 'lib/rest';
+import { ApiHostname, ApiWebsocketProtocol } from 'lib/rest';
 import SimpleCodeLine from 'components/basic/CodeSnippet/SimpleCodeLine/SimpleCodeLine';
 
 interface Props extends DevSpaceConfigContext {
@@ -26,7 +26,7 @@ export const getURLByName = (name: string) => {
     return null;
   }
 
-  return `ws://${ApiHostname()}/api/command?name=${name}`;
+  return `${ApiWebsocketProtocol()}://${ApiHostname()}/api/command?name=${name}`;
 };
 
 class CommandsList extends React.PureComponent<Props, State> {

--- a/ui/src/components/views/Logs/TerminalCache/TerminalCache.tsx
+++ b/ui/src/components/views/Logs/TerminalCache/TerminalCache.tsx
@@ -2,7 +2,7 @@ import InteractiveTerminal, { InteractiveTerminalProps } from 'components/advanc
 import { V1PodList } from '@kubernetes/client-node';
 import React from 'react';
 import { SelectedLogs } from 'components/views/Logs/LogsList/LogsList';
-import { ApiHostname } from '../../../../lib/rest';
+import { ApiHostname, ApiWebsocketProtocol } from '../../../../lib/rest';
 import AdvancedCodeLine from 'components/basic/CodeSnippet/AdvancedCodeLine/AdvancedCodeLine';
 import styles from './TerminalCache.module.scss';
 import withDevSpaceConfig, { DevSpaceConfigContext } from 'contexts/withDevSpaceConfig/withDevSpaceConfig';
@@ -58,7 +58,7 @@ class TerminalCache extends React.PureComponent<Props, State> {
       this.cache.multiLog = {
         multiple: selected.multiple,
         props: {
-          url: `ws://${ApiHostname()}/api/logs-multiple?context=${this.props.devSpaceConfig.kubeContext}&namespace=${
+          url: `${ApiWebsocketProtocol()}://${ApiHostname()}/api/logs-multiple?context=${this.props.devSpaceConfig.kubeContext}&namespace=${
             this.props.devSpaceConfig.kubeNamespace
           }&imageSelector=${selected.multiple.join('&imageSelector=')}`,
           interactive: false,
@@ -71,7 +71,7 @@ class TerminalCache extends React.PureComponent<Props, State> {
         container: selected.container,
         interactive: selected.interactive,
         props: {
-          url: `ws://${ApiHostname()}/api/${selected.interactive ? 'enter' : 'logs'}?context=${
+          url: `${ApiWebsocketProtocol()}://${ApiHostname()}/api/${selected.interactive ? 'enter' : 'logs'}?context=${
             this.props.devSpaceConfig.kubeContext
           }&namespace=${this.props.devSpaceConfig.kubeNamespace}&name=${selected.pod}&container=${selected.container}`,
           interactive: selected.interactive,

--- a/ui/src/lib/rest.ts
+++ b/ui/src/lib/rest.ts
@@ -7,3 +7,11 @@ export const ApiHostname = () => {
 
   return location.hostname + ':' + location.port;
 };
+
+export const ApiWebsocketProtocol = () => {
+  if (location.protocol === 'https:') {
+    return 'wss';
+  } else {
+    return 'ws';
+  }
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?**
resolves #2407


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would attempt to connect to non-SSL web sockets when served over SSL