### PR TITLE
docs: remove incorrect statement about BuildKit deployment name

### DIFF
--- a/docs/versioned_docs/version-5.x/configuration/images/buildkit.mdx
+++ b/docs/versioned_docs/version-5.x/configuration/images/buildkit.mdx
@@ -51,7 +51,7 @@ By setting `name` and `namespace` you can share a single BuildKit deployment for
 
 ### `inCluster.name`
 
-The option takes a string and defines the name of the BuildKit builder DevSpace will use or create if it does not exist. `name` will also be the name of the BuildKit deployment that is created by DevSpace. By default, DevSpace will create a BuildKit builder in the following form: devspace-NAMESPACE. For more information about what BuildKit builders are check the [docker docs](https://docs.docker.com/engine/reference/commandline/buildx_create/).
+The option takes a string and defines the name of the BuildKit builder DevSpace will use or create if it does not exist. By default, DevSpace will create a BuildKit builder with the name: devspace-NAMESPACE. For more information about what BuildKit builders are check the [docker docs](https://docs.docker.com/engine/reference/commandline/buildx_create/).
 
 ### `inCluster.rootless`
 
@@ -158,4 +158,3 @@ DevSpace allows you to configure the following build options:
 ### `options.buildArgs`
 
 <FragmentBuildOptionsBuildArgs/>
-


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?**
A user was attempting to manage the BuildKit Daemon using [instructions from this repo](https://github.com/moby/buildkit/tree/master/examples/kubernetes#deployment--service) in order to increase replicas and use a Horizontal Pod Autoscaler. However, the `buildctl` command is not supported by DevSpace, and our docs were misleading in that the Deployment created for the BuildKit Daemon would match the name given in the `inCluster.name` option.

Instead, this name is passed to `docker buildx create --driver kubernetes` which creates a deployment with a different name, usually `${inCluster.name}0`. There is not an option to directly control the deployment name.

**Please provide a short message that should be published in the DevSpace release notes**
Fixed misleading documentation about BuildKit Daemon deployments


**What else do we need to know?** 
Recommended that the user create the builder with `docker buildx create --driver kubernetes --bootstrap` and use the generated manifests as a starting point for their customizations.