### PR TITLE
feat: add global flag for running dep sequentially

### DIFF
--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/run_dependency_pipelines.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/run_dependency_pipelines.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/jessevdk/go-flags"
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
 	types2 "github.com/loft-sh/devspace/pkg/devspace/dependency/types"
@@ -9,7 +11,6 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/pipeline/types"
 	"github.com/loft-sh/devspace/pkg/util/stringutil"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 // RunDependencyPipelinesOptions describe how dependencies should get deployed

--- a/pkg/devspace/pipeline/pipeline.go
+++ b/pkg/devspace/pipeline/pipeline.go
@@ -224,10 +224,13 @@ func (p *pipeline) StartNewDependencies(ctx devspacecontext.Context, dependencie
 
 	// Start sequentially
 	if options.Sequential {
+		ctx.Log().Debug("Deploying dependencies sequentially")
 		for _, dependency := range deployDependencies {
 			err := p.startNewDependency(ctx, dependency, options)
 			if err != nil {
 				return errors.Wrapf(err, "run dependency %s", dependency.Name())
+			} else {
+				ctx.Log().Debugf("Dependency '%s' deployed", dependency.Name())
 			}
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2380 


**Please provide a short message that should be published in the DevSpace release notes**
Added global flag `--sequential-dependencies` which deploys dependencies sequentially.

