### PR TITLE
fix: port forward to local registry with multiple dependencies

### DIFF
--- a/pkg/devspace/build/registry/deployment.go
+++ b/pkg/devspace/build/registry/deployment.go
@@ -17,9 +17,9 @@ import (
 
 func (r *LocalRegistry) ensureDeployment(ctx devspacecontext.Context) (*appsv1.Deployment, error) {
 	// Switching from a persistent registry, delete the statefulset.
-	_, err := ctx.KubeClient().KubeClient().AppsV1().StatefulSets(r.options.Namespace).Get(ctx.Context(), r.options.Name, metav1.GetOptions{})
+	_, err := ctx.KubeClient().KubeClient().AppsV1().StatefulSets(r.Namespace).Get(ctx.Context(), r.Name, metav1.GetOptions{})
 	if err == nil {
-		err := ctx.KubeClient().KubeClient().AppsV1().StatefulSets(r.options.Namespace).Delete(ctx.Context(), r.options.Name, metav1.DeleteOptions{})
+		err := ctx.KubeClient().KubeClient().AppsV1().StatefulSets(r.Namespace).Delete(ctx.Context(), r.Name, metav1.DeleteOptions{})
 		if err != nil && kerrors.IsNotFound(err) {
 			return nil, err
 		}
@@ -32,13 +32,13 @@ func (r *LocalRegistry) ensureDeployment(ctx devspacecontext.Context) (*appsv1.D
 	err = wait.PollImmediateWithContext(ctx.Context(), time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
 		var err error
 
-		existing, err = kubeClient.KubeClient().AppsV1().Deployments(r.options.Namespace).Get(ctx, r.options.Name, metav1.GetOptions{})
+		existing, err = kubeClient.KubeClient().AppsV1().Deployments(r.Namespace).Get(ctx, r.Name, metav1.GetOptions{})
 		if err == nil {
 			return true, nil
 		}
 
 		if kerrors.IsNotFound(err) {
-			existing, err = kubeClient.KubeClient().AppsV1().Deployments(r.options.Namespace).Create(ctx, desired, metav1.CreateOptions{})
+			existing, err = kubeClient.KubeClient().AppsV1().Deployments(r.Namespace).Create(ctx, desired, metav1.CreateOptions{})
 			if err == nil {
 				return true, nil
 			}
@@ -61,7 +61,7 @@ func (r *LocalRegistry) ensureDeployment(ctx devspacecontext.Context) (*appsv1.D
 	if err != nil {
 		return nil, err
 	}
-	return ctx.KubeClient().KubeClient().AppsV1().Deployments(r.options.Namespace).Apply(
+	return ctx.KubeClient().KubeClient().AppsV1().Deployments(r.Namespace).Apply(
 		ctx.Context(),
 		applyConfiguration,
 		metav1.ApplyOptions{
@@ -74,18 +74,18 @@ func (r *LocalRegistry) ensureDeployment(ctx devspacecontext.Context) (*appsv1.D
 func (r *LocalRegistry) getDeployment() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: r.options.Name,
+			Name: r.Name,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": r.options.Name,
+					"app": r.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": r.options.Name,
+						"app": r.Name,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -93,13 +93,13 @@ func (r *LocalRegistry) getDeployment() *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name:  "registry",
-							Image: r.options.Image,
+							Image: r.Image,
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/v2/",
 										Port: intstr.IntOrString{
-											IntVal: int32(r.options.Port),
+											IntVal: int32(r.Port),
 										},
 									},
 								},
@@ -114,7 +114,7 @@ func (r *LocalRegistry) getDeployment() *appsv1.Deployment {
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/v2/",
 										Port: intstr.IntOrString{
-											IntVal: int32(r.options.Port),
+											IntVal: int32(r.Port),
 										},
 									},
 								},

--- a/pkg/devspace/build/registry/options.go
+++ b/pkg/devspace/build/registry/options.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"path"
+
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 )
 
@@ -19,6 +21,10 @@ type Options struct {
 	StorageEnabled   bool
 	StorageSize      string
 	StorageClassName string
+}
+
+func getID(o Options) string {
+	return path.Join(o.Namespace, o.Name)
 }
 
 func NewDefaultOptions() Options {

--- a/pkg/devspace/build/registry/service.go
+++ b/pkg/devspace/build/registry/service.go
@@ -21,13 +21,13 @@ func (r *LocalRegistry) ensureService(ctx devspacecontext.Context) (*corev1.Serv
 	err := wait.PollImmediateWithContext(ctx.Context(), time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
 		var err error
 
-		existing, err = kubeClient.KubeClient().CoreV1().Services(r.options.Namespace).Get(ctx, r.options.Name, metav1.GetOptions{})
+		existing, err = kubeClient.KubeClient().CoreV1().Services(r.Namespace).Get(ctx, r.Name, metav1.GetOptions{})
 		if err == nil {
 			return true, nil
 		}
 
 		if kerrors.IsNotFound(err) {
-			existing, err = kubeClient.KubeClient().CoreV1().Services(r.options.Namespace).Create(ctx, desired, metav1.CreateOptions{})
+			existing, err = kubeClient.KubeClient().CoreV1().Services(r.Namespace).Create(ctx, desired, metav1.CreateOptions{})
 			if err == nil {
 				return true, nil
 			}
@@ -51,7 +51,7 @@ func (r *LocalRegistry) ensureService(ctx devspacecontext.Context) (*corev1.Serv
 		return nil, err
 	}
 
-	return ctx.KubeClient().KubeClient().CoreV1().Services(r.options.Namespace).Apply(
+	return ctx.KubeClient().KubeClient().CoreV1().Services(r.Namespace).Apply(
 		ctx.Context(),
 		applyConfiguration,
 		metav1.ApplyOptions{
@@ -64,21 +64,21 @@ func (r *LocalRegistry) ensureService(ctx devspacecontext.Context) (*corev1.Serv
 func (r *LocalRegistry) getService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: r.options.Name,
+			Name: r.Name,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
 					Name:     "registry",
 					Protocol: corev1.ProtocolTCP,
-					Port:     int32(r.options.Port),
+					Port:     int32(r.Port),
 					TargetPort: intstr.IntOrString{
-						IntVal: int32(r.options.Port),
+						IntVal: int32(r.Port),
 					},
 				},
 			},
 			Selector: map[string]string{
-				"app": r.options.Name,
+				"app": r.Name,
 			},
 			Type: corev1.ServiceTypeNodePort,
 		},


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #2411
Fixes ENG-603


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace could not reuse a local registry if required by multiple dependencies


**What else do we need to know?** 
This is a basic fix, where the registry is matched by name. If dependencies use different registry configurations, then the last one wins.