### PR TITLE
fix: generate keys using ecdsa instead of rsa

### DIFF
--- a/pkg/devspace/services/proxycommands/commands.go
+++ b/pkg/devspace/services/proxycommands/commands.go
@@ -3,6 +3,8 @@ package proxycommands
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
+
 	sshpkg "github.com/gliderlabs/ssh"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
@@ -13,7 +15,6 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
 	"github.com/loft-sh/devspace/pkg/util/tomb"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 var DefaultRemotePort = 10567

--- a/pkg/devspace/services/ssh/config.go
+++ b/pkg/devspace/services/ssh/config.go
@@ -1,16 +1,17 @@
 package ssh
 
 import (
-	"github.com/loft-sh/devspace/pkg/util/log"
-	"github.com/loft-sh/devspace/pkg/util/scanner"
-	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/loft-sh/devspace/pkg/util/log"
+	"github.com/loft-sh/devspace/pkg/util/scanner"
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 )
 
 var configLock sync.Mutex


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2435 


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace use to generate ssh keys with RSA and now the SHA-1 is deprecated this generated keys were having trouble in the authentication.

