### PR TITLE
fix: Prevent constant rebuilding with local registry

### DIFF
--- a/pkg/devspace/build/builder/buildkit/buildkit.go
+++ b/pkg/devspace/build/builder/buildkit/buildkit.go
@@ -68,7 +68,7 @@ func (b *Builder) Build(ctx devspacecontext.Context) error {
 func (b *Builder) ShouldRebuild(ctx devspacecontext.Context, forceRebuild bool) (bool, error) {
 	// Check if image is present in local registry
 	imageCache, _ := ctx.Config().LocalCache().GetImageCache(b.helper.ImageConfigName)
-	imageName := imageCache.ResolveImage()
+	imageName := imageCache.ResolveImage() + ":" + imageCache.Tag
 
 	if imageCache.IsLocalRegistryImage() {
 		found, err := registry.IsImageAvailableRemotely(ctx.Context(), imageName)

--- a/pkg/devspace/build/builder/docker/docker.go
+++ b/pkg/devspace/build/builder/docker/docker.go
@@ -75,7 +75,7 @@ func (b *Builder) Build(ctx devspacecontext.Context) error {
 func (b *Builder) ShouldRebuild(ctx devspacecontext.Context, forceRebuild bool) (bool, error) {
 	// Check if image is present in local registry
 	imageCache, _ := ctx.Config().LocalCache().GetImageCache(b.helper.ImageConfigName)
-	imageName := imageCache.ResolveImage()
+	imageName := imageCache.ResolveImage() + ":" + imageCache.Tag
 
 	if imageCache.IsLocalRegistryImage() {
 		found, err := registry.IsImageAvailableRemotely(ctx.Context(), imageName)


### PR DESCRIPTION
Added missing image tag to `ShouldRebuild()`
to detect that an image is already present in the
registry and to prevent constant rebuilds.

Closes #2442

**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #2442
Fixes ENG-722 


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace was always rebuilding images for local registry even if it should not.
