### PR TITLE
Perhaps add a note that the sample values break a deploy

### DIFF
--- a/docs/pages/_partials/kustomize-options-kustomizeArgs.mdx
+++ b/docs/pages/_partials/kustomize-options-kustomizeArgs.mdx
@@ -18,3 +18,5 @@ Deploying the above example would roughly be equivalent to this command:
 ```bash
 kustomize build --timeout=10s --grace-period=30 -f backend/
 ```
+
+**Note:** Directly copying the example shown above would result in your deploy failing (it would result in `Error: unknown flag: --timeout`).


### PR DESCRIPTION
Either add a note like this _or_ replace the shown kustomizeArgs values with ones that _do_ work? I tried the manifest as shown and they break the deploy since that is not a valid kustomize command (at least not with the _latest_ version of it, perhaps they used to work):

`create_deployments: error deploying app: error executing 'kustomize build ./k8s/base --timeout 30s --grace-period 30': Error: unknown flag: --timeout`

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?**
Text edit to clarify

**Please provide a short message that should be published in the DevSpace release notes**
Updated docs

**What else do we need to know?** 
