### PR TITLE
docs: add note about forcing variables to string

### DIFF
--- a/docs/pages/configuration/variables.mdx
+++ b/docs/pages/configuration/variables.mdx
@@ -6,6 +6,7 @@ sidebar_label: ${VARIABLES}
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import ConfigPartial from './_partials/v2beta1/vars.mdx'
+import FragmentVarsForceString from '../_partials/vars-force-string.mdx';
 
 DevSpace allows you to make your configuration dynamic by using variables.
 
@@ -35,6 +36,8 @@ DevSpace lets you define custom varables inside `devspace.yaml` within the `vars
 :::tip Mix & Match Variable Types
 You can define several types of variables in the same config file, e.g. one `devspace.yaml` can contain static variables, env variables and more.
 :::
+
+<FragmentVarsForceString/>
 
 ### With Static Value
 To add variables with static value, just provide the value for the respective variable:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?**
Adds missing documentation about forcing variables to strings using `$!{MY_VAR}`.

**What else do we need to know?** 
Several users have been tripped up by this recently.