### PR TITLE
Section commands such as devspace run [command] do not work when the k8s cluster is unavailable

### DIFF
--- a/pkg/devspace/config/remotecache/loader.go
+++ b/pkg/devspace/config/remotecache/loader.go
@@ -3,6 +3,9 @@ package remotecache
 import (
 	"context"
 	"encoding/base64"
+	"errors"
+	"syscall"
+
 	"github.com/loft-sh/devspace/pkg/devspace/config/localcache"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/util/encoding"
@@ -115,7 +118,7 @@ type cacheLoader struct {
 func (c *cacheLoader) Load(ctx context.Context, client kubectl.Client) (Cache, error) {
 	remoteCache, err := NewCacheFromSecret(ctx, client, c.secretName)
 	if err != nil {
-		if !kerrors.IsNotFound(err) && !kerrors.IsForbidden(err) {
+		if !kerrors.IsNotFound(err) && !kerrors.IsForbidden(err) && !errors.Is(err, syscall.ECONNREFUSED) {
 			return nil, err
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2470
Fixes ENG-802

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace commands would fail when the selected Kubernetes cluster is unavailable
