### PR TITLE
Feature: Add support for InlineManifest blocks in Kubectl deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .DS_STORE
 .idea
 .devspace/
+tags
 
 # VS Code
 .vscode/ipch

--- a/e2e/tests/deploy/testdata/kubectl_inline_manifest/devspace.yaml
+++ b/e2e/tests/deploy/testdata/kubectl_inline_manifest/devspace.yaml
@@ -1,0 +1,17 @@
+version: v2beta1
+
+deployments:
+  test:
+    kubectl:
+      inlineManifest: |-
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: pods-simple-pod-2
+        spec:
+          containers:
+            - command:
+                - sleep
+                - "3600"
+              image: busybox
+              name: pods-simple-container-2

--- a/examples/inlineManifest/.dockerignore
+++ b/examples/inlineManifest/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.devspace/
+kube/
+node_modules/

--- a/examples/inlineManifest/devspace.yaml
+++ b/examples/inlineManifest/devspace.yaml
@@ -1,0 +1,66 @@
+version: v2beta1
+name: inline-manifest
+
+deployments:
+  quickstart:
+    kubectl:
+      inlineManifest: |-
+        kind: Deployment
+        apiVersion: apps/v1
+        metadata:
+          name: devspace
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: default
+              app.kubernetes.io/name: devspace-app
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: default
+                app.kubernetes.io/name: devspace-app
+            spec:
+              containers:
+                - name: default
+                  # The correct image tag will be inserted during devspace dev / devspace deploy
+                  image: mydockeruser/quickstart
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          labels:
+            app.kubernetes.io/name: devspace-app
+          name: external
+        spec:
+          ports:
+          - name: port-0
+            port: 80
+            protocol: TCP
+            targetPort: 3000
+          selector:
+            app.kubernetes.io/component: default
+            app.kubernetes.io/name: devspace-app
+          type: ClusterIP
+
+dev:
+  my-dev:
+    imageSelector: mydockeruser/quickstart
+    # Use this image for development
+    devImage: loftsh/javascript:latest
+    # Start port forwarding
+    ports:
+    - port: 3000
+    # Start file sync
+    sync:
+    - path: ./
+      excludePaths:
+      - node_modules
+    # Open url as soon as ready
+    open:
+      - url: http://localhost:3000
+    # Start terminal forwarding with script entrypoint
+    terminal:
+      command: ./devspace_start.sh
+    # Start remote ssh server
+    ssh: {}

--- a/examples/inlineManifest/devspace_start.sh
+++ b/examples/inlineManifest/devspace_start.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set +e  # Continue on errors
+
+export NODE_ENV=development
+if [ -f "yarn.lock" ] && [ ! -d "node_modules" ]; then
+   echo "Installing Yarn Dependencies"
+   yarn
+else 
+   if [ -f "package.json" ] && [ ! -d "node_modules" ]; then
+      echo "Installing NPM Dependencies"
+      npm install
+   fi
+fi
+
+COLOR_CYAN="\033[0;36m"
+COLOR_RESET="\033[0m"
+
+echo -e "${COLOR_CYAN}
+   ____              ____
+  |  _ \  _____   __/ ___| _ __   __ _  ___ ___
+  | | | |/ _ \ \ / /\___ \| '_ \ / _\` |/ __/ _ \\
+  | |_| |  __/\ V /  ___) | |_) | (_| | (_|  __/
+  |____/ \___| \_/  |____/| .__/ \__,_|\___\___|
+                          |_|
+${COLOR_RESET}
+Welcome to your development container!
+This is how you can work with it:
+- Run \`${COLOR_CYAN}npm start${COLOR_RESET}\` to start the application
+- ${COLOR_CYAN}Files will be synchronized${COLOR_RESET} between your local machine and this container
+- Use \`${COLOR_CYAN}ssh my-dev.quickstart.devspace${COLOR_RESET}\` to access the application via SSH
+- Some ports will be forwarded, so you can access this container on your local machine via ${COLOR_CYAN}http://localhost:3000${COLOR_RESET}
+"
+
+bash

--- a/pkg/devspace/config/loader/loader_test.go
+++ b/pkg/devspace/config/loader/loader_test.go
@@ -1469,16 +1469,16 @@ vars:
 version: v1beta7
 deployments:
 - name: test
-  kubectl: 
+  kubectl:
     manifests:
     - test.yaml
 - name: test2
-  kubectl: 
+  kubectl:
     manifests:
     - test.yaml
 profiles:
 - name: parent
-	replace: 
+	replace:
 		images:
 			test:
 				image: test
@@ -1543,6 +1543,50 @@ purge_deployments replaced2 test2 --sequential`,
 			},
 		},
 		{
+			name: "Inline manifest and normal manifest error",
+			in: &parseTestCaseInput{
+				config: `
+version: v2beta1
+name: inline-manifest
+
+deployments:
+	test:
+		kubectl:
+			manifests:
+				- test.yaml
+			inlineManifest: |-
+				kind: Deployment
+				apiVersion: apps/v1
+				metadata:
+					name: test
+				spec:
+					replicas: 1
+					selector:
+					matchLabels:
+						app.kubernetes.io/component: default
+						app.kubernetes.io/name: test
+					template:
+					metadata:
+						labels:
+						app.kubernetes.io/component: default
+						app.kubernetes.io/name: test
+					spec:
+						containers:
+						- name: default
+							image: test
+profiles:
+- name: test
+	replace:
+		images:
+			test:
+				image: test`,
+				options:         &ConfigOptions{Profiles: []string{"test"}},
+				generatedConfig: &localcache.LocalCache{Vars: map[string]string{}},
+			},
+			expectedErr: "deployments[test].kubectl.manifests and deployments[test].kubectl.inlineManifest cannot be used together",
+		},
+
+		{
 			name: "Profile loop error",
 			in: &parseTestCaseInput{
 				config: `
@@ -1553,7 +1597,7 @@ deployments:
 profiles:
 - name: parent
 	parent: test
-	replace: 
+	replace:
 		images:
 			test:
 				image: test

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -868,6 +868,8 @@ type KubectlConfig struct {
 	// KubectlBinaryPath is the optional path where to find the kubectl binary
 	KubectlBinaryPath string `yaml:"kubectlBinaryPath,omitempty" json:"kubectlBinaryPath,omitempty"`
 
+	// InlineManists is a block containing the manifest to deploy
+	InlineManifest string `yaml:"inlineManifest,omitempty" json:"inlineManifest,omitempty"`
 	// Kustomize can be used to enable kustomize instead of kubectl
 	Kustomize *bool `yaml:"kustomize,omitempty" json:"kustomize,omitempty" jsonschema_extras:"group=kustomize,group_name=Kustomize"`
 	// KustomizeArgs are extra arguments for `kustomize build` which will be run before `kubectl apply`

--- a/pkg/devspace/config/versions/validate.go
+++ b/pkg/devspace/config/versions/validate.go
@@ -256,8 +256,11 @@ func validateDeployments(config *latest.Config) error {
 		if deployConfig.Helm == nil && deployConfig.Kubectl == nil {
 			return errors.Errorf("Please specify either helm or kubectl as deployment type in deployment %s", deployConfig.Name)
 		}
-		if deployConfig.Kubectl != nil && deployConfig.Kubectl.Manifests == nil {
-			return errors.Errorf("deployments[%s].kubectl.manifests is required", index)
+		if deployConfig.Kubectl != nil && deployConfig.Kubectl.Manifests == nil && deployConfig.Kubectl.InlineManifest == "" {
+			return errors.Errorf("deployments[%s].kubectl.manifests or deployments[%s].kubectl.InlineManifest is required", index, index)
+		}
+		if deployConfig.Kubectl != nil && deployConfig.Kubectl.Manifests != nil && deployConfig.Kubectl.InlineManifest != "" {
+			return errors.Errorf("deployments[%s].kubectl.manifests and deployments[%s].kubectl.inlineManifest cannot be used together", index, index)
 		}
 		if deployConfig.Kubectl != nil && deployConfig.Helm != nil {
 			return errors.Errorf("deployments[%s].kubectl and deployments[%s].helm cannot be used together", index, index)

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl_test.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl_test.go
@@ -87,6 +87,29 @@ func TestNew(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Inline Manifest",
+			deployConfig: &latest.DeploymentConfig{
+				Name: "someDeploy3",
+				Kubectl: &latest.KubectlConfig{
+					KubectlBinaryPath: "someCmdPath3",
+					InlineManifest:    "inline: manifest",
+				},
+			},
+			expectedDeployer: &DeployConfig{
+				Name:           "someDeploy3",
+				CmdPath:        "someCmdPath3",
+				InlineManifest: "inline: manifest",
+
+				DeploymentConfig: &latest.DeploymentConfig{
+					Name: "someDeploy3",
+					Kubectl: &latest.KubectlConfig{
+						KubectlBinaryPath: "someCmdPath3",
+						InlineManifest:    "inline: manifest",
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -487,7 +510,7 @@ func TestGetReplacedManifest(t *testing.T) {
 
 		devCtx := devspacecontext.NewContext(context.Background(), nil, log.NewFakeLogger()).WithConfig(conf)
 
-		shouldRedeploy, replacedManifest, _, err := deployer.getReplacedManifest(devCtx, testCase.manifest)
+		shouldRedeploy, replacedManifest, _, err := deployer.getReplacedManifest(devCtx, false, testCase.manifest)
 
 		if testCase.expectedErr == "" {
 			assert.NilError(t, err, "Error in testCase %s", testCase.name)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature


**Please provide a short message that should be published in the DevSpace release notes**
This should make possible to use inline manifests in `kubectl` blocks, for example:

```yaml
version: v2beta1
name: inline-manifest

vars:
  IMAGE: nginx:1.14.2

deployments:
  my-deployment:
    kubectl:
      inlineManifest: |-
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: nginx-deployment
          labels:
            app: nginx
        spec:
          replicas: 3
          selector:
            matchLabels:
              app: nginx
          template:
            metadata:
              labels:
                app: nginx
            spec:
              containers:
              - name: nginx
                image: ${IMAGE}
                ports:
                - containerPort: 80
```


**What else do we need to know?** 

- [x] Need to update tests with the new use case
- [x] I specified that it is not possible to have both `manifests` and `inlineManifest` at the same time, but we might want to revise this decision?
- [x] For now the example in `examples/inlineManifest` is not working, need to work on that